### PR TITLE
HTTP/HTTPS vector tile sources

### DIFF
--- a/lib/source.js
+++ b/lib/source.js
@@ -136,7 +136,7 @@ source.save = function(data, callback) {
     var id = data.id;
     var uri = url.parse(data.id);
     var perm = !source.tmpid(id);
-    var remote = uri.protocol === 'mapbox:';
+    var remote = ['mapbox:', 'http:', 'https:'].indexOf(uri.protocol) >= 0;
 
     // "Soft" write for remote sources.
     if (remote) return source.info(id, function(err, info) {

--- a/lib/source.js
+++ b/lib/source.js
@@ -51,9 +51,15 @@ var cache = {};
 module.exports = source;
 tilelive.protocols['mapbox:'] = source;
 tilelive.protocols['tmsource:'] = source;
+tilelive.protocols['http:'] = source;
+tilelive.protocols['https:'] = source;
 
 source.defaults = defaults;
 source.deflayer = deflayer;
+
+var protocolIsValid = function (protocol) {
+    return _(['tmsource:', 'mapbox:', 'http:', 'https:']).contains(protocol);
+};
 
 function source(arg, callback) {
     if ('string' !== typeof arg) {
@@ -64,7 +70,7 @@ function source(arg, callback) {
         var uri = url.parse(arg);
     }
 
-    if (uri.protocol !== 'tmsource:' && uri.protocol !== 'mapbox:')
+    if (!protocolIsValid(uri.protocol))
         return callback(new Error('Invalid source protocol'));
 
     if (cache[id]) return callback(null, cache[id]);
@@ -287,22 +293,23 @@ source.normalize = function(data) {
 source.info = function(id, callback) {
     var uri = url.parse(id);
 
-    if (uri.protocol !== 'tmsource:' && uri.protocol !== 'mapbox:')
+    if (!protocolIsValid(uri.protocol))
         return callback(new Error('Invalid source protocol'));
 
     var load = function(data, callback) {
         data.id = id;
         return callback(null, data);
     };
-    switch (uri.protocol) {
-    case 'mapbox:':
-        var loaded = false;
+
+    var loadRemote = function () {
+        var loaded = false,
+            url = uri.protocol === 'mapbox:' ?  tm.config().mapboxtile + uri.pathname + '.json' : id;
         if (tm.remote(id)) {
             load(_({}).defaults(tm.remote(id)), callback);
             loaded = true;
         }
         new TileJSON.get({
-            uri: tm.config().mapboxtile + uri.pathname + '.json',
+            uri: url,
             timeout: 5000
         }).asBuffer(function(err, data) {
             if (err) return callback(err);
@@ -316,6 +323,11 @@ source.info = function(id, callback) {
                 return loaded || load(data, callback);
             }
         });
+    };
+
+    switch (uri.protocol) {
+    case 'mapbox:':
+        loadRemote();
         break;
     case 'tmsource:':
         fs.readFile(path.join(uri.pathname,'data.yml'), 'utf8', function(err, data) {
@@ -324,6 +336,12 @@ source.info = function(id, callback) {
             catch(err) { return callback(err); }
             return load(data, callback);
         });
+        break;
+    case 'http:':
+        loadRemote();
+        break;
+    case 'https:':
+        loadRemote();
         break;
     default:
         callback(new Error('Unsupported source protocol'));

--- a/lib/source.js
+++ b/lib/source.js
@@ -326,6 +326,8 @@ source.info = function(id, callback) {
     };
 
     switch (uri.protocol) {
+    case 'http:':
+    case 'https:':
     case 'mapbox:':
         loadRemote();
         break;
@@ -336,12 +338,6 @@ source.info = function(id, callback) {
             catch(err) { return callback(err); }
             return load(data, callback);
         });
-        break;
-    case 'http:':
-        loadRemote();
-        break;
-    case 'https:':
-        loadRemote();
         break;
     default:
         callback(new Error('Unsupported source protocol'));

--- a/test/source.test.js
+++ b/test/source.test.js
@@ -73,7 +73,7 @@ describe('source remote', function() {
         });
     });
     it('error bad protocol', function(done) {
-        source('http://www.google.com', function(err, source) {
+        source('invalid://www.google.com', function(err, source) {
             assert.ok(err);
             assert.equal('Invalid source protocol', err.message);
             done();

--- a/test/source.test.js
+++ b/test/source.test.js
@@ -72,6 +72,26 @@ describe('source remote', function() {
             done();
         });
     });
+    it('loads via http', function (done) {
+        source('http://a.tiles.mapbox.com/v3/mapbox.mapbox-streets-v4.json', function (err, source) {
+            assert.ifError(err);
+            assert.equal('MapBox Streets V4', source.data.name);
+            assert.equal(0, source.data.minzoom);
+            assert.equal(14, source.data.maxzoom);
+            assert.ok(!!source.style);
+            done();
+        });
+    });
+    it('loads via https', function (done) {
+        source('https://a.tiles.mapbox.com/v3/mapbox.mapbox-streets-v4.json', function (err, source) {
+            assert.ifError(err);
+            assert.equal('MapBox Streets V4', source.data.name);
+            assert.equal(0, source.data.minzoom);
+            assert.equal(14, source.data.maxzoom);
+            assert.ok(!!source.style);
+            done();
+        });
+    });
     it('error bad protocol', function(done) {
         source('invalid://www.google.com', function(err, source) {
             assert.ok(err);


### PR DESCRIPTION
This builds on @rclark's patches in #61--248beafb46496d68085dfd219bc095034f367a50 prevents TM2 from treating http(s) sources as local and trying to create (invalid) directories for them.

I've been using this successfully with [mojodna/tiled-vector-remix](https://github.com/mojodna/tiled-vector-remix).
