### PR TITLE
Clear add tab field value after tab has been added.

### DIFF
--- a/templates/style._
+++ b/templates/style._
@@ -320,11 +320,13 @@ Editor.prototype.adddata = function(ev) {
   return false;
 };
 Editor.prototype.addtab = function(ev) {
-  var filename = $('#addtab-filename').val();
+  var field = $('#addtab-filename');
+  var filename = field.val();
   if (!code[filename]) {
     $("<a rel='"+filename+"' href='#code-"+filename.replace(/[^\w+]/g,'_')+"' class='tab'>"+filename+" <span class='icon close delete'></span></a>").appendTo('nav#tabs');
     code[filename] = Tab(filename, '');
   }
+  field.val('');
   window.location.hash = '#';
   return false;
 };


### PR DESCRIPTION
Before: after creating a new tab, the old file name would still exist in the input

After: now it gets cleared.
