### PR TITLE
Style-specific layer order/instances

### DIFF
--- a/lib/style.js
+++ b/lib/style.js
@@ -31,6 +31,7 @@ var defaults = {
     format:'png8:m=h',
     template:'',
     interactivity_layer:'',
+    layers:null,
     _properties: {},
     _prefs: {
         saveCenter: true
@@ -175,15 +176,39 @@ style.toXML = function(data, callback) {
         opts.srs = tm.srs['900913'];
 
         // Convert datatiles sources to mml layers.
-        opts.Layer  = _(backend.data.vector_layers).map(function(layer) { return {
+        var layerconf = data.layers || [];
+        var classed = {};
+        var layers = [];
+        for (var i = 0; i < layerconf.length; i++) {
+            var layer = {
+                id: layerconf[i].split('.')[0],
+                'class': layerconf[i].split('.')[1]
+            };
+            // mark the layer as having a class instance.
+            if (layer['class']) {
+                classed[layer.id] = true;
+                layers.push(layer);
+            }
+        }
+        for (var i = 0; i < backend.data.vector_layers.length; i++) {
+            var layer = backend.data.vector_layers[i];
+            if (!classed[layer.id]) layers.push(layer);
+        }
+        opts.Layer = layers.map(function(layer) { return {
             id:layer.id,
             name:layer.id,
+            'class':layer['class'],
             // Styles can provide a hidden _properties key with
             // layer-specific property overrides. Current workaround to layer
             // properties that could (?) eventually be controlled via carto.
             properties: (data._properties && data._properties[layer.id]) || {},
             srs:tm.srs['900913']
         } });
+        if (data.layers && data.layers.length) opts.Layer.sort(function(a, b) {
+            a = data.layers.indexOf(a['class'] ? a.id + '.' + a['class'] : a.id);
+            b = data.layers.indexOf(b['class'] ? b.id + '.' + b['class'] : b.id);
+            return a < b ? -1 : a > b ? 1 : 0;
+        });
 
         opts.Stylesheet = _(data.styles).map(function(style,basename) { return {
             id: basename,

--- a/lib/style.js
+++ b/lib/style.js
@@ -176,24 +176,9 @@ style.toXML = function(data, callback) {
         opts.srs = tm.srs['900913'];
 
         // Convert datatiles sources to mml layers.
-        var layerconf = data.layers || [];
-        var classed = {};
-        var layers = [];
-        for (var i = 0; i < layerconf.length; i++) {
-            var layer = {
-                id: layerconf[i].split('.')[0],
-                'class': layerconf[i].split('.')[1]
-            };
-            // mark the layer as having a class instance.
-            if (layer['class']) {
-                classed[layer.id] = true;
-                layers.push(layer);
-            }
-        }
-        for (var i = 0; i < backend.data.vector_layers.length; i++) {
-            var layer = backend.data.vector_layers[i];
-            if (!classed[layer.id]) layers.push(layer);
-        }
+        var layers = data.layers ? data.layers.map(function(l) {
+            return { id: l.split('.')[0], 'class': l.split('.')[1] }
+        }) : backend.data.vector_layers;
         opts.Layer = layers.map(function(layer) { return {
             id:layer.id,
             name:layer.id,
@@ -204,11 +189,6 @@ style.toXML = function(data, callback) {
             properties: (data._properties && data._properties[layer.id]) || {},
             srs:tm.srs['900913']
         } });
-        if (data.layers && data.layers.length) opts.Layer.sort(function(a, b) {
-            a = data.layers.indexOf(a['class'] ? a.id + '.' + a['class'] : a.id);
-            b = data.layers.indexOf(b['class'] ? b.id + '.' + b['class'] : b.id);
-            return a < b ? -1 : a > b ? 1 : 0;
-        });
 
         opts.Stylesheet = _(data.styles).map(function(style,basename) { return {
             id: basename,

--- a/test/style.test.js
+++ b/test/style.test.js
@@ -152,7 +152,7 @@ describe('style.toXML', function() {
             id:'tmstyle:///tmp-1234',
             source:'mapbox:///mapbox.mapbox-streets-v2',
             styles:{'style.mss': '#water { polygon-fill:#fff } #road.line::line { line-width:0.5 } #road.label::label { line-width:1 }'},
-            layers:[ 'road.line', 'tunnel', 'road.label' ],
+            layers:[ 'water', 'bridge', 'poi_label', 'road.line', 'tunnel', 'road.label' ],
             _properties:{bridge:{'group-by':'layer'}}
         }, function(err, xml) {
             assert.ifError(err);
@@ -161,7 +161,7 @@ describe('style.toXML', function() {
             assert.ok(/group-by="layer"/.test(xml), 'includes layer properties');
             assert.ok(/<PolygonSymbolizer fill="#ffffff"/.test(xml), 'includes rule');
             // Moves specified layers last, in order.
-            assert.ok(xml.indexOf('<Layer name="road"') > xml.indexOf('<Layer name="bridge"'));
+            assert.ok(xml.indexOf('<Layer name="road"') > xml.indexOf('<Layer name="poi_label"'));
             assert.ok(xml.indexOf('<Layer name="road"') > xml.indexOf('<Layer name="road_label"'));
             assert.ok(xml.indexOf('<Layer name="tunnel"') > xml.indexOf('<Layer name="road"'));
             assert.ok(xml.indexOf('<StyleName>road-label</StyleName>') > xml.indexOf('<StyleName>road-line</StyleName>'));

--- a/test/style.test.js
+++ b/test/style.test.js
@@ -143,6 +143,28 @@ describe('style.toXML', function() {
             assert.ok(/<Layer name="water"/.test(xml), 'includes layer');
             assert.ok(/group-by="layer"/.test(xml), 'includes layer properties');
             assert.ok(/<PolygonSymbolizer fill="#ffffff"/.test(xml), 'includes rule');
+            assert.ok(xml.indexOf('<Layer name="road"') < xml.indexOf('<Layer name="bridge"'));
+            done();
+        });
+    });
+    it('compiles layer order + classed layers', function(done) {
+        style.toXML({
+            id:'tmstyle:///tmp-1234',
+            source:'mapbox:///mapbox.mapbox-streets-v2',
+            styles:{'style.mss': '#water { polygon-fill:#fff } #road.line::line { line-width:0.5 } #road.label::label { line-width:1 }'},
+            layers:[ 'road.line', 'tunnel', 'road.label' ],
+            _properties:{bridge:{'group-by':'layer'}}
+        }, function(err, xml) {
+            assert.ifError(err);
+            assert.ok(/<Map srs/.test(xml), 'looks like Mapnik XML');
+            assert.ok(/<Layer name="water"/.test(xml), 'includes layer');
+            assert.ok(/group-by="layer"/.test(xml), 'includes layer properties');
+            assert.ok(/<PolygonSymbolizer fill="#ffffff"/.test(xml), 'includes rule');
+            // Moves specified layers last, in order.
+            assert.ok(xml.indexOf('<Layer name="road"') > xml.indexOf('<Layer name="bridge"'));
+            assert.ok(xml.indexOf('<Layer name="road"') > xml.indexOf('<Layer name="road_label"'));
+            assert.ok(xml.indexOf('<Layer name="tunnel"') > xml.indexOf('<Layer name="road"'));
+            assert.ok(xml.indexOf('<StyleName>road-label</StyleName>') > xml.indexOf('<StyleName>road-line</StyleName>'));
             done();
         });
     });


### PR DESCRIPTION
https://github.com/mapbox/tm2/issues/133

Adds handling of an optional `layers` property in `project.yml`.

Styles can now reorder and create multiple instances of layers. Suppose a source has the layers

```
a
b
c
```

A style can define its own order and instances of the layers with the following property:

```
layers:
- b
- a.data
- c
- a.label
```

Where `a.label` refers to `<id>.<class>` in carto. Note that while it's possible to do something like

```
layers:
- a
- a.label
```

where one of the layer instances is classed and the other is not, in practice it is very hard to use.

No UI for this yet, will meditate on what makes sense here (reordering is straightforward, reinstancing ... not as much).

cc @ajashton @springmeyer 
