### PR TITLE
use point-line icon for data

### DIFF
--- a/templates/style._
+++ b/templates/style._
@@ -181,7 +181,7 @@
     <div class='pin-topleft fill-gray z1 keyline-bottom row1'><!--
     --><a class='pad1 inline quiet docs-n icon help unround align-middle fill-darken0 keyline-right' href='#docs'></a><!--
       --><a class='pad1 inline quiet docs-y icon x unround align-middle fill-darken0 keyline-right' href='#'></a><!--
-      --><a class='pad1 inline quiet layers-n icon menu align-middle fill-darken0 keyline-right' href='#layers'></a><!--
+      --><a class='pad1 inline quiet layers-n icon point-line align-middle fill-darken0 keyline-right' href='#layers'></a><!--
       --><a class='pad1 inline quiet layers-y icon x unround align-middle fill-darken0 keyline-right' href='#'></a>
     </div>
     <nav id='tabs' class='keyline-left row1 keyline-bottom pad0y pin-top fill-darken0 contain small'><!--


### PR DESCRIPTION
I don't like that we use the hamburger for data. We should switch to `point-line` everywhere to represent data:
![screen shot 2014-03-14 at 12 33 07 pm](https://f.cloud.github.com/assets/108094/2423198/7e88147c-ab96-11e3-8499-de544e13e9b6.png)
