### PR TITLE
Loads sql code from datasource into source form

### DIFF
--- a/templates/source._
+++ b/templates/source._
@@ -243,6 +243,7 @@ var Layer = function(id, datasource) {
   var code;
   if (datasource && (datasource.type === 'postgis' || datasource.type === 'sqlite')) {
     code = CodeMirror($('#layers-' + id + ' div.sql').get(0), {
+      value: datasource.table,
       lineNumbers: true,
       mode: 'text/x-plsql'
     });


### PR DESCRIPTION
This puts SQL from a postgis or sqlite datasource back into the CodeMirror pane. Without this things load up fine, but if you save anything you would overwrite your `data.yml` with oops no more SQL.
