### PR TITLE
rework source lists

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -188,14 +188,14 @@ fieldset section.keyline-bottom { border-bottom-color:rgba(0,0,0,.2) !important;
 a.project strong { color: white;}
 a.project:hover { background: rgba(255,255,255,.15);}
 
-a.project.active,
-a.project.active:hover { background: rgba(255,255,255,.2);}
-
-
 /* Flag active project */
 .project.proj-active,
-.project.proj-active:hover { background-color: rgba(255,255,255,.2);}
+.project.proj-active:hover {
+  background-color: rgba(255,255,255,.2);
+}
 .project.proj-active .proj-status { display: block;}
+
+.project.small-project { margin-bottom: 1px;}
 
 /* Project settings */
 #settings {
@@ -739,7 +739,6 @@ span.cm-carto-filter             { color:#66475B; }
 
 #title .avatar { width: 40px; height: 40px; }
 
-#data:target,
 #data:target ~ #layers,
 #fonts:target,
 #docs:target,
@@ -751,11 +750,12 @@ span.cm-carto-filter             { color:#66475B; }
           transform:translateX(-100%);
 }
 
-#style-ui #data,
-#fonts,
-#docs,
-#style-ui #layers {
-  z-index: -1;
+#data:target {
+box-shadow: rgba(0,0,0,0.1) -2px 0px 0px;
+  -webkit-transform:translateX(-200%);
+     -moz-transform:translateX(-200%);
+      -ms-transform:translateX(-200%);
+          transform:translateX(-200%);
 }
 
 /* map styles to compensate for col max-widths */
@@ -815,19 +815,11 @@ a.data-y { display:none; }
   border-radius:4px 0px 0px 4px;
   }
 
-a[href='#docs-points'],
 #docs-points section .type   { color: #8a8acb; } /* fill purple */
-a[href='#docs-lines'],
 #docs-lines section .type    { color: #3887be; } /* fill blue */
-a[href='#docs-polygons'],
 #docs-polygons section .type { color: #56b881; } /* fill green */
-a[href='#docs-text'],
 #docs-text section .type     { color: #ee8a65; } /* fill orange */
-a[href='#docs-misc'],
 #docs-misc section .type     { color: #EE6565; } /* fill red */
-
-.dark a[href='#docs-remote'] { color: #ee8a65; } /* fill orange */
-.dark a[href='#docs-local']  { color: #3887be; } /* fill blue */
 
 a[href='#docs-points'],
 #docs-points section   { border-left-color: #8a8acb; } /* fill purple */

--- a/app/app.css
+++ b/app/app.css
@@ -195,8 +195,6 @@ a.project:hover { background: rgba(255,255,255,.15);}
 }
 .project.proj-active .proj-status { display: block;}
 
-.project.small-project { margin-bottom: 1px;}
-
 /* Project settings */
 #settings {
   height: 100%;

--- a/templates/history._
+++ b/templates/history._
@@ -74,13 +74,15 @@
             <div class='small-graphic fallback-graphic pin-left round-left pad1 fill-lighten0'><div class='icon big point-line'></div></div>
 
             <div class='truncate pad1 '>
-              <strong><%= item.name || 'Untitled' %></strong><br />
-              <% if (item.id.indexOf('mapbox://')) { %>
-              <span class='inline quiet icon harddrive'>Local</span>
-              <% } else {%>
-              <span class='inline quiet icon cloud'>Remote</span>
-              <% } %>
-              <span class='pad0x'><code><%= item.id.split('/').pop() %></code></span>
+              <strong><%= item.name || 'Untitled' %></strong>
+              <div class='block truncate'>
+                <% if (item.id.indexOf('mapbox://')) { %>
+                <span class='inline quiet icon harddrive'>Local</span>
+                <% } else {%>
+                <span class='inline quiet icon cloud'>Remote</span>
+                <% } %>
+                <span class='pad0x'><code><%= item.id.split('/').pop() %></code></span>
+              </div>
             </div>
             <div class='z10 pad1x pad2y proj-status hidden pin-right'><span class='inline strong dot fill-blue icon check'></span></div>
           </a>

--- a/templates/history._
+++ b/templates/history._
@@ -74,12 +74,12 @@
             <div class='small-graphic fallback-graphic pin-left round-left pad1 fill-lighten0'><div class='icon big point-line'></div></div>
 
             <div class='truncate pad1 '>
-              <strong><%= item.name || 'Untitled' %></strong>
+              <strong><%= item.name || 'Untitled' %></strong><br />
               <% if (item.id.indexOf('mapbox://')) { %>
-              <span class='inline quiet pad0x icon harddrive'>Local</span>
+              <span class='inline quiet icon harddrive'>Local</span>
               <% } else {%>
-              <span class='inline quiet pad0x icon cloud'>Remote</span>
-              <% } %><br />
+              <span class='inline quiet icon cloud'>Remote</span>
+              <% } %>
               <code><%= item.id.split('/').pop() %></code>
             </div>
             <div class='z10 pad1x pad2y proj-status hidden pin-right'><span class='inline strong dot fill-blue icon check'></span></div>

--- a/templates/history._
+++ b/templates/history._
@@ -80,7 +80,7 @@
               <% } else {%>
               <span class='inline quiet icon cloud'>Remote</span>
               <% } %>
-              <code><%= item.id.split('/').pop() %></code>
+              <span class='pad0x'><code><%= item.id.split('/').pop() %></code></span>
             </div>
             <div class='z10 pad1x pad2y proj-status hidden pin-right'><span class='inline strong dot fill-blue icon check'></span></div>
           </a>

--- a/templates/modalbrowser._
+++ b/templates/modalbrowser._
@@ -8,7 +8,7 @@
 %>
 
 <form id='<%=obj.id%>' class='modal round browser col6 fill-light'>
-  <a class='pad1 quiet icon x submit pin-topright' href='#'></a>
+  <a class='pad1 quiet icon x pin-topright' href='#'></a>
   <div class='cwd row1 truncate keyline-bottom z1'>
     <a href='#<%= obj.cwd.split('/').slice(0,-1).join('/') %>' class='inline pad1 quiet icon prev unround'></a><!--
     --><strong><%=cwd%></strong>

--- a/templates/source._
+++ b/templates/source._
@@ -33,7 +33,7 @@
   <a href='#' class='fill-darken1 col12 pin-left pin-bottom'></a>
   <div class='project-settings dark fill-dark round contain col4 pin-topleft'>
     <% var disabled = remote ? "disabled='disabled'" : ''; %>
-    <a class="pad1 quiet icon x submit pin-topright" href="#"></a>
+    <a class="pad1 quiet icon x pin-topright" href="#"></a>
     <header class='pad2 keyline-bottom'>
       <h3>Settings</h3>
     </header>
@@ -151,8 +151,8 @@ revlayers.reverse();
   <div id='layers'>
     <nav class='pad1x row1 col12 pin-top keyline-bottom fill-dark z1'>
       <div class='pin-topleft z1 row1'><!--
-        --><a class='pad1 inline docs-n icon help unround align-middle fill-darken0 keyline-right' href='#docs'></a><!--
-        --><a class='pad1 inline docs-y icon help unround align-middle fill-darken2 keyline-right' href='#'></a><!--
+        --><a title='Documentation' class='pad1 inline docs-n icon help unround align-middle fill-darken0 keyline-right' href='#docs'></a><!--
+        --><a title='Documentation' class='pad1 inline docs-y icon help unround align-middle fill-darken2 keyline-right' href='#'></a><!--
       --></div>
       <% if (remote) { %>
       <strong class='small inline pad1y pad4x'>Layers</strong>
@@ -205,7 +205,7 @@ revlayers.reverse();
 
 <% if (!remote) { %>
 <form id='addlayer' class='modal round pad2 col6 margin3 fill-light'>
-  <a class="pad1 quiet icon x submit pin-topright" href="#"></a>
+  <a class="pad1 quiet icon x pin-topright" href="#"></a>
   <fieldset class='col8 margin2 space-bottom1'>
     <input class='col12 space-bottom1' type='text' placeholder='layername' title='No spaces allowed.' size='20' name='id' pattern='\w+'/>
   </fieldset>

--- a/templates/sourcedocs._
+++ b/templates/sourcedocs._
@@ -2,6 +2,7 @@
 <article class='fill-darken1 small' id='docs-intro'>
 <div class="row1 pad1 keyline-bottom">
   <h3>Source editor help</h3>
+  <a class='pad1 quiet icon x pin-topright' href='#'></a>
 </div>
 
 <nav class='small clearfix col12 contain z1 strong'>

--- a/templates/sourceitem._
+++ b/templates/sourceitem._
@@ -1,11 +1,10 @@
-<a href='#source-<%=obj.id%>' class='fill-lighten0 project small-project contain col12 small strong quiet js-adddata <%=obj.active ? 'proj-active js-recache' : ''%>'>
-  <div class='pad1'>
-    <strong class='block'><%= obj.name || 'Untitled' %></strong>
-    <% if (obj.id.indexOf('mapbox://')) { %>
-    <span class='inline quiet icon harddrive'>Local</span>
-    <% } else {%>
-    <span class='inline quiet icon cloud'>Remote</span>
-    <% } %>
-
-  </div>
-</a>
+<div class='pad1x space-bottom0'>
+    <a href='#source-<%=obj.id%>' class='pad0 round project small-project contain col12 small strong quiet js-adddata <%=obj.active ? 'proj-active js-recache' : ''%>'>
+        <strong class='block'><%= obj.name || 'Untitled' %></strong>
+        <% if (obj.id.indexOf('mapbox://')) { %>
+        <span class='inline quiet icon harddrive'>Local</span>
+        <% } else {%>
+        <span class='inline quiet icon cloud'>Remote</span>
+        <% } %>
+    </a>
+</div>

--- a/templates/sourceitem._
+++ b/templates/sourceitem._
@@ -1,10 +1,11 @@
 <div class='pad1x space-bottom0'>
-    <a href='#source-<%=obj.id%>' class='pad0 round project small-project contain col12 small strong quiet js-adddata <%=obj.active ? 'proj-active js-recache' : ''%>'>
+    <a href='#source-<%=obj.id%>' class='pad1 round project small-project contain col12 small strong quiet js-adddata <%=obj.active ? 'proj-active js-recache' : ''%>'>
         <strong class='block'><%= obj.name || 'Untitled' %></strong>
         <% if (obj.id.indexOf('mapbox://')) { %>
         <span class='inline quiet icon harddrive'>Local</span>
         <% } else {%>
         <span class='inline quiet icon cloud'>Remote</span>
         <% } %>
+        <div class='proj-status hidden pad1 pin-bottomright'><span class='inline strong icon refresh'>Refresh</span></div>
     </a>
 </div>

--- a/templates/sourceitem._
+++ b/templates/sourceitem._
@@ -1,13 +1,11 @@
-<div class='col12 fl space-bottom1'><a href='#source-<%=obj.id%>' class='project contain col12 round small strong quiet inline fill-lighten0 js-adddata <%=obj.active ? 'active js-recache' : ''%>'>
-  <span class='z1 contain fill-lighten0 small-graphic inline round-left fl' style='background-image:url("/thumb.png?id=<%=obj.id%>&mtime=<%=obj.mtime%>")'></span>
-  <div class='small-graphic fallback-graphic pin-left round-left pad1 fill-lighten0'><div class='icon big point-line'></div></div>
-  <div class='pad1 truncate'>
-    <strong><%= obj.name || 'Untitled' %></strong>
+<a href='#source-<%=obj.id%>' class='fill-lighten0 project small-project contain col12 small strong quiet js-adddata <%=obj.active ? 'proj-active js-recache' : ''%>'>
+  <div class='pad1'>
+    <strong class='block'><%= obj.name || 'Untitled' %></strong>
     <% if (obj.id.indexOf('mapbox://')) { %>
-    <span class='inline quiet pad0x icon harddrive'>Local</span>
+    <span class='inline quiet icon harddrive'>Local</span>
     <% } else {%>
-    <span class='inline quiet pad0x icon cloud'>Remote</span>
-    <% } %><br />
-    <code><%= obj.description || 'No description.' %></code>
+    <span class='inline quiet icon cloud'>Remote</span>
+    <% } %>
+
   </div>
-</a></div>
+</a>

--- a/templates/sourcelayers._
+++ b/templates/sourcelayers._
@@ -4,11 +4,6 @@
   <strong class='block'>
   <%= obj.name || 'Untitled' %>
   </strong>
-  <% if (obj.tiles) { %>
-  <span name='remote' class='inline quiet icon cloud'>Remote</span>
-  <% } else { %>
-  <span name='local' class='inline quiet icon harddrive'>Local</span>
-  <% } %>
 </a>
 
 <% _(obj.vector_layers).chain().clone().reverse().each(function(l) { %>

--- a/templates/sourcelayers._
+++ b/templates/sourcelayers._
@@ -1,18 +1,14 @@
 <div id='<%= obj.id %>' class='contain js-source source'>
 
-<div class='pin-topright pad0'>
-<a class='button quiet short icon round refresh js-recache' href='#recache'></a>
-</div>
-
-<a href='#data' class='small block keyline-bottom pad1 clearfix'>
-  <strong>
+<a href='#data' class='strong small block keyline-bottom pad1 clearfix'>
+  <strong class='block'>
   <%= obj.name || 'Untitled' %>
-  <% if (obj.tiles) { %>
-  <span name='remote' class='inline quiet pad0x icon cloud'>Remote</span>
-  <% } else { %>
-  <span name='local' class='inline quiet pad0x icon harddrive'>Local</span>
-  <% } %>
   </strong>
+  <% if (obj.tiles) { %>
+  <span name='remote' class='inline quiet icon cloud'>Remote</span>
+  <% } else { %>
+  <span name='local' class='inline quiet icon harddrive'>Local</span>
+  <% } %>
 </a>
 
 <% _(obj.vector_layers).chain().clone().reverse().each(function(l) { %>

--- a/templates/style._
+++ b/templates/style._
@@ -36,7 +36,7 @@
   </div>
   <a href='#' class='fill-darken1 col12 pin-left pin-bottom'></a>
   <div class='project-settings fill-light round contain col4 pin-topleft'>
-  <a class="pad1 quiet icon x submit pin-topright" href="#"></a>
+  <a class="pad1 quiet icon x pin-topright" href="#"></a>
     <header class='pad2 keyline-bottom'>
       <h3>Settings</h3>
     </header>
@@ -161,7 +161,7 @@
   <div id='data' class='pin-left animate fill-blue dark scroll-styled col6'>
     <section class='pad1 space-bottom1 keyline-bottom contain'>
       <h3>Available sources</h3>
-      <a class="pad1 quiet icon x submit pin-topright" href="#layers"></a>
+      <a class="pad1 quiet icon x pin-topright" href="#layers"></a>
     </section>
     <%
       print(_(history.source).chain()
@@ -194,6 +194,7 @@
   <div id='layers' class='pane animate pin-left col6 menu dark fill-dark scroll-styled'>
     <nav class='row1 col12 pad1 fill-dark keyline-bottom z100'>
       <h3>Active source</h3>
+      <a class='pad1 quiet icon x pin-topright' href='#'></a>
     </nav>
     <div class='js-menu-content col12 scroll-styled'>
       <%= _(sources).map(this.sourcelayers).join('\n') %>
@@ -203,10 +204,10 @@
   <div id='code' class='z1 pin-left col12'>
   <div class='row1 fill-light pin-top'>
     <div class='pin-topleft fill-gray z1 keyline-bottom row1'><!--
-    --><a class='pad1 inline quiet docs-n icon help unround align-middle fill-darken0 keyline-right' href='#docs'></a><!--
-      --><a class='pad1 inline dark docs-y icon help unround align-middle fill-darken2 keyline-right' href='#'></a><!--
-      --><a class='pad1 inline quiet layers-n icon point-line align-middle fill-darken0 keyline-right' href='#layers'></a><!--
-      --><a class='pad1 inline dark layers-y icon point-line unround align-middle fill-darken2 keyline-right' href='#'></a>
+    --><a title='Documentation' class='pad1 inline quiet docs-n icon help unround align-middle fill-darken0 keyline-right' href='#docs'></a><!--
+      --><a title='Documentation' class='pad1 inline dark docs-y icon help unround align-middle fill-darken2 keyline-right' href='#'></a><!--
+      --><a title='Data layers' class='pad1 inline quiet layers-n icon point-line align-middle fill-darken0 keyline-right' href='#layers'></a><!--
+      --><a title='Data layers' class='pad1 inline dark layers-y icon point-line unround align-middle fill-darken2 keyline-right' href='#'></a>
     </div>
     <nav id='tabs' class='keyline-left row1 keyline-bottom pad0y pin-top fill-darken0 contain small'><!--
       --><a rel='template' href='#code-template' class='tab js-tab round quiet mini icon tooltip'></a><!--
@@ -265,7 +266,7 @@
 <%= style._tmp ? this.modalbrowsersave({cwd:cwd, type:'style'}) : '' %>
 
 <form id='addtab' class='modal center round pad2 col6 margin3 fill-light'>
-  <a class="pad1 quiet icon x submit pin-topright" href="#"></a>
+  <a class="pad1 quiet icon x pin-topright" href="#"></a>
   <div class='clearfix'>
     <span class='input-pill pill col8 margin2'>
       <input class='col8' type='text' placeholder='filename' size='20' id='addtab-filename' required/><!--

--- a/templates/style._
+++ b/templates/style._
@@ -159,7 +159,7 @@
 <div id='style-ui' class='animate z1 col6 pin-right fill-light'>
 
   <div id='data' class='pin-left animate fill-blue dark scroll-styled col6'>
-    <section class='pad1 keyline-bottom contain'>
+    <section class='pad1 space-bottom1 keyline-bottom contain'>
       <h3>Available sources</h3>
       <a class="pad1 quiet icon x submit pin-topright" href="#layers"></a>
     </section>

--- a/templates/style._
+++ b/templates/style._
@@ -158,25 +158,21 @@
 
 <div id='style-ui' class='animate z1 col6 pin-right fill-light'>
 
-  <div id='data' class='pane pin-left animate fill-blue dark scroll-styled col12'>
-    <div class='col6'>
-      <section class='pad1 keyline-bottom contain'>
-        <h3>Sources</h3>
-        <a class="pad1 quiet icon x submit pin-topright" href="#layers"></a>
-      </section>
-      <div class='grid pad1 clearfix'>
-      <%
-        print(_(history.source).chain()
-          .sortBy(function(item) {
-            return (item.name||'').toLowerCase();
-          })
-          .map(function(item) {
-            return this.sourceitem(_({active:item.id === style.source}).defaults(item));
-          }.bind(this))
-          .value().join(''));
-      %>
-      </div>
-    </div>
+  <div id='data' class='pin-left animate fill-blue dark scroll-styled col6'>
+    <section class='pad1 keyline-bottom contain'>
+      <h3>Available sources</h3>
+      <a class="pad1 quiet icon x submit pin-topright" href="#layers"></a>
+    </section>
+    <%
+      print(_(history.source).chain()
+        .sortBy(function(item) {
+          return (item.name||'').toLowerCase();
+        })
+        .map(function(item) {
+          return this.sourceitem(_({active:item.id === style.source}).defaults(item));
+        }.bind(this))
+        .value().join(''));
+    %>
   </div>
 
   <div id='docs' class='pane animate pin-left fill-grey scroll-styled col6'>
@@ -204,7 +200,7 @@
     </div>
   </div>
 
-  <div id='code'>
+  <div id='code' class='z1 pin-left col12'>
   <div class='row1 fill-light pin-top'>
     <div class='pin-topleft fill-gray z1 keyline-bottom row1'><!--
     --><a class='pad1 inline quiet docs-n icon help unround align-middle fill-darken0 keyline-right' href='#docs'></a><!--
@@ -635,13 +631,13 @@ Editor.prototype.focusSearch = function(ev) {
 };
 Editor.prototype.adddata = function(ev) {
   var target = $(ev.currentTarget);
-  if (target.is('.active')) return false;
+  if (target.is('.proj-active')) return false;
   var id = target.attr('href').split('#source-').pop();
   (new Source({id:id})).fetch({
     success: _(function(model, resp) {
-      $('#data a.active').removeClass('js-recache active');
+      $('#data a.proj-active').removeClass('js-recache proj-active');
       $('#layers .js-menu-content').html(templates.sourcelayers(resp));
-      target.addClass('js-recache active');
+      target.addClass('js-recache proj-active');
     }).bind(this),
     error: _(this.error).bind(this)
   });

--- a/templates/styledocs._
+++ b/templates/styledocs._
@@ -26,18 +26,19 @@ var sections = {
     }
 };
 %>
-<div class="row1 pad1 keyline-bottom">
+<div class="row1 pad1 contain keyline-bottom">
   <h3>Style editor help</h3>
-  <a href='#fonts' class='quiet pad1 small keyline-left strong fill-darken0 icon font short font-link pin-topright'>Fonts</a>
+  <a class='pad1 quiet icon x pin-topright' href='#'></a>
 </div>
 
 <nav class='fill-grey small clearfix col12 contain z1 strong'>
-  <a href='#docs-intro'    class='js-docs-nav docs-nav row1 block quiet'><div class='col12 pad1 keyline-bottom icon home'>Overview</div></a>
-  <a href='#docs-points'   class='js-docs-nav docs-nav row1 block quiet'><div class='col12 pad1 keyline-bottom icon marker'>Points</div></a>
-  <a href='#docs-lines'    class='js-docs-nav docs-nav row1 block quiet'><div class='col12 pad1 keyline-bottom icon polyline'>Lines</div></a>
-  <a href='#docs-polygons' class='js-docs-nav docs-nav row1 block quiet'><div class='col12 pad1 keyline-bottom icon polygon'>Polygons</div></a>
-  <a href='#docs-text'     class='js-docs-nav docs-nav row1 block quiet'><div class='col12 pad1 keyline-bottom icon pencil'>Text</div></a>
-  <a href='#docs-misc'     class='js-docs-nav docs-nav row1 block quiet'><div class='col12 pad1 keyline-bottom icon star'>Misc</div></a>
+  <a href='#fonts'         class='fill-darken0 quiet block row1 small strong'><div class='pad1 keyline-bottom icon font'>Fonts</div></a>
+  <a href='#docs-intro'    class='js-docs-nav docs-nav row1 block quiet'><div class='pad1 keyline-bottom icon home'>Overview</div></a>
+  <a href='#docs-points'   class='js-docs-nav docs-nav row1 block quiet'><div class='pad1 keyline-bottom icon marker'>Points</div></a>
+  <a href='#docs-lines'    class='js-docs-nav docs-nav row1 block quiet'><div class='pad1 keyline-bottom icon polyline'>Lines</div></a>
+  <a href='#docs-polygons' class='js-docs-nav docs-nav row1 block quiet'><div class='pad1 keyline-bottom icon polygon'>Polygons</div></a>
+  <a href='#docs-text'     class='js-docs-nav docs-nav row1 block quiet'><div class='pad1 keyline-bottom icon pencil'>Text</div></a>
+  <a href='#docs-misc'     class='js-docs-nav docs-nav row1 block quiet'><div class='pad1 keyline-bottom icon star'>Misc</div></a>
 </nav>
 
 <article class='small' id='docs-intro'>


### PR DESCRIPTION
Move remote/local tag to second line in #projects - 

![screen shot 2014-04-02 at 10 56 00 pm](https://cloud.githubusercontent.com/assets/108094/2599242/88a9a8fe-badb-11e3-8242-70b6705e8d61.png)

Differentiate when selecting source for style editing:

![screen shot 2014-04-02 at 10 54 50 pm](https://cloud.githubusercontent.com/assets/108094/2599244/8fd9726c-badb-11e3-9880-f92300f7e5f7.png)

I dropped the thumbnail, because thumbnail made this feel too much like the #settings browsing interface. If it helps for scanning I could bring it back.
