### PR TITLE
Add mention of maxzoom/minzoom on layer of source

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Local TM2 source transform traditional geodata formats (shapefiles, geojson, pos
 When configuring your source there are several parameters to give extra attention:
 
 - **Maxzoom (source)**: the highest zoom level for which vector tiles should be rendered. After this zoom level styles using this source will *overzoom*, using geometries from the maxzoom level. If this value is set too low, geometries will appear crude/oversimplified at higher zoomlevels. If this value is set too high, you will need to generate many more vector tiles than necessary for your data.
+- **Maxzoom/Minzoom (layer)**: the highest zoom level for which this source should be visible. Not to be confused with the `maxzoom` at the source level. Since a source may contain more than one layer, this allows you to selectively hide layers above or below certain zoom levels.
 - **Buffer size (layer)**: the number of "pixel" units geometries should extend beyond tile boundaries. If set too low, especially for lines and polygons, geometries will not extend beyond tiles enough to allow for wide strokes, blurs, and other styles. Higher values, however, include more geometry data in each vector tile bloating size.
 
 ### Exporting and uploading a source MBTiles


### PR DESCRIPTION
/cc @yhahn - did I get this right?

Adds mention of maxzoom/minzoom on source layers to help avoid confusion with maxzoom of source itself because these settings, while named the same, have very different meanings.
