### PR TITLE
tm2 no longer works offline

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,10 @@ function auth(req, res, next) {
         return next();
     }
     request(tm._config.mapboxauth+'/api/Map/'+tm.db._docs.oauth.account+'.tm2-basemap?access_token='+tm.db._docs.oauth.accesstoken, function(error, response, body) {
+        if (error) {
+            return next(error);
+        }
+
         if (response.statusCode >= 400) {
             var data = {
                 '_type': 'composite',


### PR DESCRIPTION
...after adding OAuth authorization with Mapbox.

This patch prevents an app crash in favor of displaying the error message, but the app remains non-functional when offline.

I'm not sure what the more general fix should look like.
