### PR TITLE
Don't crash when data.yml is malformed

### DIFF
--- a/lib/source.js
+++ b/lib/source.js
@@ -77,6 +77,8 @@ function source(arg, callback) {
 
     source.info(id, function(err, data) {
         if (err) return callback(err);
+	if (typeof(data) !== 'object')
+            return callback(new Error('Malformed source YAML configuration.'));
         data = source.normalize(data);
         source.toXML(data, function(err, xml) {
             if (err) return callback(err);


### PR DESCRIPTION
There is probably a better way to do this. We should probably also check if data is null (data.yml is empty).
