### PR TITLE
Tests cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+test/fixtures-oauth/test-clone.db

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,19 +10,3 @@ addons:
 before_install:
  - createdb template_postgis
  - psql -c "CREATE EXTENSION postgis" template_postgis
-
-install:
- - npm install
-
-before_script:
- - npm install mocha
- - npm ls
-
-script:
- - node ./test/fixtures-oauth/mapbox.js &
- - node index.js --mapboxauth="http://localhost:3001" --db="./test/fixtures-oauth/test.db" &
- - sleep 10
- - ./node_modules/.bin/mocha-phantomjs "http://localhost:3000/style?id=tmstyle:///tmp-1371d3fb&test=true"
- - sleep 10
- - npm test
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,7 @@ addons:
 before_install:
  - createdb template_postgis
  - psql -c "CREATE EXTENSION postgis" template_postgis
+
+before_script:
+ - npm install mocha
+ - npm ls

--- a/lib/source.js
+++ b/lib/source.js
@@ -12,8 +12,8 @@ var Bridge = require('tilelive-bridge');
 var TileJSON = require('tilejson');
 var tilelive = require('tilelive');
 var style;
-var CachingTileJSON = require('./cache')(TileJSON, tm.config().cache);
-var CachingBridge = require('./cache')(Bridge, tm.config().cache);
+var CachingTileJSON = require('./cache');
+var CachingBridge = require('./cache');
 var mapnik = require('mapnik');
 var mapnikref = require('mapnik-reference').version.latest;
 
@@ -125,9 +125,11 @@ source.refresh = function(data, xml, callback) {
         var opts = {};
         opts.xml = xml;
         opts.base = !source.tmpid(id) && uri.pathname;
-        return cache[id] ? cache[id].update(opts, done) : new CachingBridge(opts, done);
+        var cb = CachingBridge(Bridge, tm.config().cache);
+        return cache[id] ? cache[id].update(opts, done) : new cb(opts, done);
     } else {
-        return cache[id] ? done(null, cache[id]) : new CachingTileJSON({data:data}, done);
+        var ctj = CachingTileJSON(TileJSON, tm.config().cache);
+        return cache[id] ? done(null, cache[id]) : new ctj({data:data}, done);
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
   },
   "scripts": {
     "start": "./index.js",
-    "test": "mocha -R spec"
+    "test": "./test/test-runner.sh"
   }
 }

--- a/test/test-runner.sh
+++ b/test/test-runner.sh
@@ -4,9 +4,6 @@ set -e -x
 # Kill sub-processes when this script is finished
 trap 'kill $(jobs -p)' EXIT
 
-# Run backend tests
-mocha -R spec
-
 # Make a working copy of the test database that is excluded in .gitignore
 cp ./test/fixtures-oauth/test.db ./test/fixtures-oauth/test-clone.db
 
@@ -22,5 +19,8 @@ styleId=${result[1]}
 # Run front-end tests
 ./node_modules/.bin/mocha-phantomjs "http://localhost:3000/style?id=$styleId&test=true"
 sleep 10
+
+# Run backend tests
+mocha -R spec
 
 exit 0

--- a/test/test-runner.sh
+++ b/test/test-runner.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e -x
+
+# Kill sub-processes when this script is finished
+trap 'kill $(jobs -p)' EXIT
+
+# Run backend tests
+mocha -R spec
+
+# Make a working copy of the test database that is excluded in .gitignore
+cp ./test/fixtures-oauth/test.db ./test/fixtures-oauth/test-clone.db
+
+# Run mock oauth server and tm2
+node ./test/fixtures-oauth/mapbox.js &
+node index.js --mapboxauth="http://localhost:3001" --db="./test/fixtures-oauth/test-clone.db" &
+sleep 10
+
+# Make a tmp style
+IFS='=' read -ra result <<< "$(curl -s http://localhost:3000/new/style)"
+styleId=${result[1]}
+
+# Run front-end tests
+./node_modules/.bin/mocha-phantomjs "http://localhost:3000/style?id=$styleId&test=true"
+sleep 10
+
+exit 0

--- a/test/test-runner.sh
+++ b/test/test-runner.sh
@@ -4,6 +4,9 @@ set -e -x
 # Kill sub-processes when this script is finished
 trap 'kill $(jobs -p)' EXIT
 
+# Run backend tests
+mocha -R spec
+
 # Make a working copy of the test database that is excluded in .gitignore
 cp ./test/fixtures-oauth/test.db ./test/fixtures-oauth/test-clone.db
 
@@ -19,8 +22,5 @@ styleId=${result[1]}
 # Run front-end tests
 ./node_modules/.bin/mocha-phantomjs "http://localhost:3000/style?id=$styleId&test=true"
 sleep 10
-
-# Run backend tests
-mocha -R spec
 
 exit 0


### PR DESCRIPTION
I wanted to be able to run `npm test` and run both front and backend tests. I didn't like that the steps to running the frontend tests were hidden in .travis.yml. That meant writing a [`test-runner.sh`](https://github.com/mapbox/tm2/blob/travis-cleanup/test/test-runner.sh), adjusting `.travis.yml` and then Travis led me down a little rabbit hole.
1. @tristen: some of the other refactoring I've done to the style routes has meant there is a distinct difference between _making a style_ and _loading a style_. As a result I have to [make a call to create a temporary style before I can load it up for tests](https://github.com/mapbox/tm2/blob/travis-cleanup/test/test-runner.sh#L18-L23). I wonder how you feel about this?
2. @yhahn: I found that if I `rm -rf ~/.tilemill/v2/cache` and then ran `mocha -R spec`, that tests that involved loading a source in any way would fail. This is because the `tm` object is configured by the test scripts _after_ [these caching modules are `require`d](https://github.com/mapbox/tm2/blob/master/lib/source.js#L15-L16). As a result calls to `tm.config` are unlikely to behave the way you expect them too if you've already required `style.js` or `source.js`. I changed `source.js` so that the caching objects initialize more on-demand-ish. Please have a look and make sure you don't see any hidden negative consequences.
