### PR TITLE
Remove need for extensions

### DIFF
--- a/templates/history._
+++ b/templates/history._
@@ -33,7 +33,7 @@
             <div class='pin-left small-graphic fallback-graphic fill-lighten0 pad1 round-left style'><div class='icon big paint'></div></div>
             <div class='pad1 truncate'>
               <strong class='style-name'><%= item.name || 'Untitled' %></strong><br />
-              <code><%= item.id.split('/').pop() %></code>
+              <code><%= item.id.split('/').pop().replace('.tm2', '') %></code>
             </div>
             <div class='z10 pad1x pad2y proj-status hidden pin-right'><span class='inline strong dot fill-blue icon check'></span></div>
           </a>

--- a/templates/libjs._
+++ b/templates/libjs._
@@ -113,6 +113,15 @@ var delStyle = function(ev) {
   return false;
 };
 
+var justName = function(name, ext) {
+  // removes the given extension if present
+  var split = name.split('.');
+  if (split.pop() == ext) {
+    return split.join('.');
+  }
+  return name;
+}
+
 var views = {};
 
 views.Browser = Backbone.View.extend({});

--- a/templates/libjs._
+++ b/templates/libjs._
@@ -115,11 +115,19 @@ var delStyle = function(ev) {
 
 var justName = function(name, ext) {
   // removes the given extension if present
-  var split = name.split('.');
-  if (split.pop() == ext) {
-    return split.join('.');
+  if (ext[0] != '.') ext = '.' + ext;
+  if (name.length - name.indexOf(ext) === ext.length) {
+    // name has extension, we must remove it
+    return name.substr(0, name.indexOf(ext));
+  } else {
+    return name;
   }
-  return name;
+}
+
+var addExtension = function(name, ext) {
+  // return a name, adding the extension if needed
+  if (ext[0] != '.') ext = '.' + ext;
+  return justName(name, ext) + ext;
 }
 
 var views = {};

--- a/templates/libjs._
+++ b/templates/libjs._
@@ -113,23 +113,6 @@ var delStyle = function(ev) {
   return false;
 };
 
-var justName = function(name, ext) {
-  // removes the given extension if present
-  if (ext[0] != '.') ext = '.' + ext;
-  if (name.indexOf(ext) !== -1 && name.length - name.indexOf(ext) === ext.length) {
-    // name has extension, we must remove it
-    return name.substr(0, name.indexOf(ext));
-  } else {
-    return name;
-  }
-}
-
-var addExtension = function(name, ext) {
-  // return a name, adding the extension if needed
-  if (ext[0] != '.') ext = '.' + ext;
-  return justName(name, ext) + ext;
-}
-
 var views = {};
 
 views.Browser = Backbone.View.extend({});

--- a/templates/modalbrowseropen._
+++ b/templates/modalbrowseropen._
@@ -7,9 +7,9 @@
   id: 'browse' + obj.type,
   cwd: obj.cwd,
   label: 'Open',
-  hint: 'No spaces allowed. Requires ".tm2" extension.',
-  placeholder: type + '.tm2',
-  pattern: '[\\w+\\d+\\.-]+\\.tm2'
+  hint: 'Letters and numbers only',
+  placeholder: type + ' name',
+  pattern: '[\\w+\\d+\\s\\.-]+'
 })); %>
 <script>
 new views.Browser({
@@ -18,6 +18,8 @@ new views.Browser({
   isFile: function(file) { return /\.tm2$/.test(file) },
   callback: function(err, filepath) {
     if (err) return false; // @TODO
+    filepath = filepath.split(' ').join('_');
+    filepath = filepath.replace(/.tm2/, '') + '.tm2';
     window.location = '/<%=type%>?id=tm<%=type%>://' + filepath;
     return false;
   }

--- a/templates/modalbrowsersave._
+++ b/templates/modalbrowsersave._
@@ -6,9 +6,9 @@
 <% print(this.modalbrowser({
   id: 'saveas',
   cwd: cwd,
-  hint: 'No spaces allowed. Requires ".tm2" extension.',
-  placeholder: type + '.tm2',
-  pattern: '[\\w+\\d+\\.\\/_-]+\\.tm2'
+  hint: 'Letters and numbers only',
+  placeholder: type + ' name',
+  pattern: '[\\w+\\d+\\.\\s\\/_-]+'
 })); %>
 <script>
 new views.Browser({
@@ -16,6 +16,8 @@ new views.Browser({
   filter: function(file) { return file.type === 'dir' && !(/\.tm2$/).test(file.basename) },
   callback: function(err, filepath) {
     if (err) return false; // @TODO
+    filepath = filepath.split(' ').join('_');
+    filepath = addExtension(filepath, '.tm2');
     var id = 'tm<%=type%>://' + filepath;
     window.editor.model.set({id:id});
     window.editor.save(null, {

--- a/templates/modalbrowsersave._
+++ b/templates/modalbrowsersave._
@@ -17,7 +17,7 @@ new views.Browser({
   callback: function(err, filepath) {
     if (err) return false; // @TODO
     filepath = filepath.split(' ').join('_');
-    filepath = addExtension(filepath, '.tm2');
+    filepath = filepath.replace(/.tm2/,'') + '.tm2';
     var id = 'tm<%=type%>://' + filepath;
     window.editor.model.set({id:id});
     window.editor.save(null, {

--- a/templates/style._
+++ b/templates/style._
@@ -279,7 +279,7 @@
   <a class="pad1 quiet icon x pin-topright" href="#"></a>
   <div class='clearfix'>
     <span class='input-pill pill col8 margin2'>
-      <input class='col8' type='text' placeholder='filename' size='20' id='addtab-filename' required/><!--
+      <input class='col8' type='text' placeholder='stylesheet name' size='20' id='addtab-filename' required/><!--
       --><input class='col4 round-right' type='submit' value='New tab'/>
     </span>
   </div>
@@ -342,7 +342,7 @@ var code = _(<%=JSON.stringify(style.styles)%>).reduce(function(memo, value, k) 
   return memo;
 }, {});
 
-// Add in interactivity template.
+// Add in interactivity template. 
 code['template'] = Tab('template', <%=JSON.stringify(style.template)%>);
 
 _(code).toArray().shift().getWrapperElement().className += ' active';
@@ -658,12 +658,13 @@ Editor.prototype.adddata = function(ev) {
 };
 Editor.prototype.addtab = function(ev) {
   var field = $('#addtab-filename');
-  var filename = field.val().split('.')[0] + '.mss';
+  var name = justName(field.val(), 'mss');
+  var filename = name + '.mss';
   if (!code[filename]) {
-    $("<a rel='"+filename+"' href='#code-"+filename.replace(/[^\w+]/g,'_')+"' class='strong quiet tab js-tab round pad0y pad1x truncate'>"+filename.replace(/.mss/,'')+" <span class='icon trash js-deltab pin-topright round pad1'></span></a><!--").insertAfter('.carto-tabs a:last-child');
+    $("<a rel='"+filename+"' href='#code-"+filename.replace(/[^\w+]/g,'_')+"' class='strong quiet tab js-tab round pad0y pad1x truncate'>"+name+" <span class='icon trash js-deltab pin-topright round pad1'></span></a><!--").insertAfter('.carto-tabs a:last-child');
     code[filename] = Tab(filename, '');
   } else {
-    editor.messagemodal('Tab name must be different than existing tab "' + field.val() + '"');
+    editor.messagemodal('Tab name must be different than existing tab "' + name + '"');
     field.val('');
     return false;
   }
@@ -678,7 +679,7 @@ Editor.prototype.deltab = function(ev) {
   if (!styles[target]) {
     $(code[target].getWrapperElement()).remove();
     parent.remove();
-  } else if (confirm('Remove stylesheet "' + target + '"?')) {
+  } else if (confirm('Remove stylesheet "' + justName(target, 'mss') + '"?')) {
     $(code[target].getWrapperElement()).remove();
     parent.remove();
     delete styles[target];

--- a/templates/style._
+++ b/templates/style._
@@ -680,10 +680,9 @@ Editor.prototype.adddata = function(ev) {
 };
 Editor.prototype.addtab = function(ev) {
   var field = $('#addtab-filename');
-  var name = justName(field.val(), 'mss');
-  var filename = name + '.mss';
+  var filename = field.val().replace(/.mss/,'') + '.mss';
   if (!code[filename]) {
-    $('.carto-tabs').append("<a rel='"+filename+"' href='#code-"+filename.replace(/[^\w+]/g,'_')+"' class='strong quiet tab js-tab round pad0y pad1x truncate'>"+name+" <span class='icon trash js-deltab pin-topright round pad1'></span></a><!--");
+    $('.carto-tabs').append("<a rel='"+filename+"' href='#code-"+filename.replace(/[^\w+]/g,'_')+"' class='strong quiet tab js-tab round pad0y pad1x truncate'>"+filename.replace(/.mss/,'')+" <span class='icon trash js-deltab pin-topright round pad1'></span></a><!--");
     code[filename] = Tab(filename, '');
   } else {
     editor.messagemodal('Tab name must be different than existing tab "' + name + '"');
@@ -701,7 +700,7 @@ Editor.prototype.deltab = function(ev) {
   if (!styles[target]) {
     $(code[target].getWrapperElement()).remove();
     parent.remove();
-  } else if (confirm('Remove stylesheet "' + justName(target, 'mss') + '"?')) {
+  } else if (confirm('Remove stylesheet "' + target.replace(/.mss/,'') + '"?')) {
     $(code[target].getWrapperElement()).remove();
     parent.remove();
     delete styles[target];

--- a/templates/style._
+++ b/templates/style._
@@ -685,7 +685,7 @@ Editor.prototype.addtab = function(ev) {
     $('.carto-tabs').append("<a rel='"+filename+"' href='#code-"+filename.replace(/[^\w+]/g,'_')+"' class='strong quiet tab js-tab round pad0y pad1x truncate'>"+filename.replace(/.mss/,'')+" <span class='icon trash js-deltab pin-topright round pad1'></span></a><!--");
     code[filename] = Tab(filename, '');
   } else {
-    editor.messagemodal('Tab name must be different than existing tab "' + name + '"');
+    editor.messagemodal('Tab name must be different than existing tab "' + filename.replace(/.mss/,'') + '"');
     field.val('');
     return false;
   }


### PR DESCRIPTION
Ref #288.

You don't need to specify the extension when creating tabs, style/source saving, style/source opening.

Still need extensions when specifying sources like .geojson .sqlite, etc... but those are mostly clicked anyway.
