### PR TITLE
Remove min/maxzoom properties from individual layer defs + UI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,8 @@ Creating a source with TM2
 
 Local TM2 source transform traditional geodata formats (shapefiles, geojson, postgis, etc.) into vector tiles. A `data.yml` file captures a configuration of datasources organized as named layers. There is no visual style associated with any given source and the source UI of TM2 autogenerates an inspection style only for viewing your data.
 
-When configuring your source there are several parameters to give extra attention:
+When configuring your source give extra attention to:
 
-- **Maxzoom (source)**: the highest zoom level for which vector tiles should be rendered. After this zoom level styles using this source will *overzoom*, using geometries from the maxzoom level. If this value is set too low, geometries will appear crude/oversimplified at higher zoomlevels. If this value is set too high, you will need to generate many more vector tiles than necessary for your data.
 - **Buffer size (layer)**: the number of "pixel" units geometries should extend beyond tile boundaries. If set too low, especially for lines and polygons, geometries will not extend beyond tiles enough to allow for wide strokes, blurs, and other styles. Higher values, however, include more geometry data in each vector tile bloating size.
 
 ### Exporting and uploading a source MBTiles

--- a/lib/source.js
+++ b/lib/source.js
@@ -40,8 +40,6 @@ var deflayer = {
     fields: {},
     Datasource: {},
     properties: {
-        minzoom:0,
-        maxzoom:22,
         'buffer-size':0
     }
 };
@@ -277,8 +275,6 @@ source.normalize = function(data) {
             var info = {};
             info.id = l.id;
             if ('description' in l) info.description = l.description;
-            if ('minzoom' in l.properties) info.minzoom = l.properties.minzoom;
-            if ('maxzoom' in l.properties) info.maxzoom = l.properties.maxzoom;
             info.fields = [];
             try {
                 var opts = _(l.Datasource).clone();

--- a/templates/layerconf._
+++ b/templates/layerconf._
@@ -6,16 +6,6 @@
     </select>
   </section>
   <section class='pad2x pad1y keyline-bottom'>
-    <label class='col3 inline'>Minzoom</label>
-    <input id='<%=obj.id%>-minzoom' name='properties-minzoom' class='min' type='range' value='<%= obj.properties.minzoom %>' min='0' max='22' step='1' onchange='rangeHandler(this, "max", "#<%=obj.id%>-maxzoom");' />
-    <span class='small quiet code inline range' id='<%=obj.id%>-minzoom-val'><%= obj.properties.minzoom %></span>
-  </section>
-  <section class='pad2x pad1y keyline-bottom'>
-    <label class='col3 inline'>Maxzoom</label>
-    <input id='<%=obj.id%>-maxzoom' name='properties-maxzoom' class='max' type='range' value='<%= obj.properties.maxzoom %>' min='0' max='22' step='1' onchange='rangeHandler(this, "min", "#<%=obj.id%>-minzoom");' />
-    <span class='small quiet code inline range' id='<%=obj.id%>-maxzoom-val'><%= obj.properties.maxzoom %></span>
-  </section>
-  <section class='pad2x pad1y keyline-bottom'>
     <label class='col3 inline'>Buffer size</label>
     <% if (obj.properties['buffer-size'] > 128) { %>
     <input id='<%=obj.id%>-buffer-size' name='properties-buffer-size' type='text' value='<%= obj.properties['buffer-size'] %>' size='12' />

--- a/test/expected/copytask-info.json
+++ b/test/expected/copytask-info.json
@@ -23,8 +23,6 @@
     {
       "id": "box",
       "description": "",
-      "minzoom": 0,
-      "maxzoom": 6,
       "fields": {
         "ScaleRank": "String",
         "FeatureCla": "String",
@@ -36,8 +34,6 @@
     {
       "id": "solid",
       "description": "",
-      "minzoom": 0,
-      "maxzoom": 6,
       "fields": {
         "Id": "Number"
       }

--- a/test/expected/source-save-data.xml
+++ b/test/expected/source-save-data.xml
@@ -6,7 +6,7 @@
   <Parameter name="attribution"><![CDATA[&copy; John Doe 2013.]]></Parameter>
   <Parameter name="center">0,0,3</Parameter>
   <Parameter name="format">pbf</Parameter>
-  <Parameter name="json"><![CDATA[{"vector_layers":[{"id":"box","description":"","minzoom":0,"maxzoom":6,"fields":{"Id":"Number"}}]}]]></Parameter>
+  <Parameter name="json"><![CDATA[{"vector_layers":[{"id":"box","description":"","fields":{"Id":"Number"}}]}]]></Parameter>
   <Parameter name="maxzoom">6</Parameter>
   <Parameter name="minzoom">0</Parameter>
   <Parameter name="name"><![CDATA[Test source]]></Parameter>


### PR DESCRIPTION
This is confusing to 99% of users and the 1% know how to do this without relying on mapnik layer def help.
