### PR TITLE
Dirty compact

### DIFF
--- a/lib/tm.js
+++ b/lib/tm.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var url = require('url');
 var path = require('path');
 var yaml = require('js-yaml');
+var dirty = require('dirty');
 var mapnik = require('mapnik');
 var mkdirp = require('mkdirp');
 var chrono = require('chrono');
@@ -41,44 +42,58 @@ tm.config = function(opts, callback) {
     // Register default plugins. Used for font rendering.
     mapnik.register_default_input_plugins();
 
-    // Load + compact the app database.
-    var old = require('dirty')(tm.config().db);
-    old.on('load', function() {
-        var db_name = tm.config().db;
-        if (existsSync(db_name)) {
-            fs.unlinkSync(db_name);
-        }
-        tm.db = require('dirty')(db_name);
-
-        // Check app db version and run any migrations if necessary.
-        switch (old.get('version')) {
-        case 2:
-            old.forEach(function(k,v) { tm.db.set(k,v); });
-            break;
-        case 1:
-        case undefined:
-            old.set('version', 2);
-            old.set('history', _(old.get('history')||{}).reduce(function(memo, list, type) {
-                if (type !== 'style' && type !== 'source') return memo;
-                memo[type] = list.map(function(id) {
-                    var uri = url.parse(id);
-                    if (uri.protocol === 'mapbox:') {
-                        return !uri.pathname ? id.replace('://', ':///') : id;
-                    } else if (!uri.protocol) {
-                        return 'tm' + type + '://' + uri.pathname;
-                    } else {
-                        return id;
-                    }
-                });
-                return memo;
-            }, { style:[], source:[] }));
-            old.forEach(function(k,v) { tm.db.set(k,v); });
-            break;
-        };
-
+    tm.dbcompact(tm.config().db, function(err, db) {
+        if (err && callback) return callback(err);
+        tm.dbmigrate(db);
+        tm.db = db;
         if (callback) return callback();
     });
+
     return tm._config;
+};
+
+// Run migrations on a node-dirty database.
+tm.dbmigrate = function(db) {
+    switch(db.get('version')) {
+    case 1:
+        db.set('version', 2);
+        db.set('history', _(db.get('history')||{}).reduce(function(memo, list, type) {
+            if (type !== 'style' && type !== 'source') return memo;
+            memo[type] = list.map(function(id) {
+                var uri = url.parse(id);
+                if (uri.protocol === 'mapbox:') {
+                    return !uri.pathname ? id.replace('://', ':///') : id;
+                } else if (!uri.protocol) {
+                    return 'tm' + type + '://' + uri.pathname;
+                } else {
+                    return id;
+                }
+            });
+            return memo;
+        }, { style:[], source:[] }));
+        break;
+    }
+};
+
+// Compact a node-dirty database. Works by loading an old instance of the db,
+// copying all docs into memory, deleting the old db and writing a new one
+// in its place.
+tm.dbcompact = function(filepath, callback) {
+    var old = dirty(filepath);
+    var olddb = {};
+    old.once('read_close', function() {
+        fs.unlink(filepath, function(err) {
+            if (err && err.code !== 'ENOENT') return callback(err);
+            var db = dirty(filepath);
+            for (var k in olddb) db.set(k, olddb[k]);
+            return callback(null, db);
+        });
+    });
+    old.once('load', function() {
+        old.forEach(function(k,v) { olddb[k] = v; });
+        old.close();
+        if (!Object.keys(olddb).length) old.emit('read_close');
+    });
 };
 
 // Set or remove a project id from recent history.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "tilejson": "~0.6.3",
     "mbtiles": "0.4.x",
     "mkdirp": "0.3.x",
-    "dirty": "0.9.x",
+    "dirty": "0.9.9",
     "sphericalmercator": "1.0.x",
     "js-yaml": "https://github.com/mapbox/js-yaml/tarball/scalar-styles",
     "fstream": "0.1.x",

--- a/test/fixtures-dirty/noncompact.db
+++ b/test/fixtures-dirty/noncompact.db
@@ -1,0 +1,12 @@
+{"key":"test","val":1}
+{"key":"test","val":2}
+{"key":"test","val":3}
+{"key":"test","val":4}
+{"key":"test","val":1}
+{"key":"test","val":2}
+{"key":"test","val":3}
+{"key":"test","val":4}
+{"key":"test","val":1}
+{"key":"test","val":2}
+{"key":"test","val":3}
+{"key":"test","val":4}

--- a/test/fixtures-dirty/schema-v1.db
+++ b/test/fixtures-dirty/schema-v1.db
@@ -1,0 +1,2 @@
+{"key":"version","val":1}
+{"key":"history","val":{"style":["/no-protocol/path/style.tm2"],"source":["mapbox://mapbox.mapbox-streets-v2"],"dummy":["badvalue"]}}

--- a/test/tm.test.js
+++ b/test/tm.test.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var assert = require('assert');
 var tm = require('../lib/tm');
+var dirty = require('dirty');
 
 describe('tm', function() {
 
@@ -12,12 +13,49 @@ describe('tm', function() {
             cache: path.join(tmppath, 'cache')
         }, done);
     });
+    before(function(done) {
+        fs.writeFileSync(path.join(tmppath, 'noncompact.db'), fs.readFileSync(path.join(__dirname, 'fixtures-dirty', 'noncompact.db')));
+        fs.writeFileSync(path.join(tmppath, 'schema-v1.db'), fs.readFileSync(path.join(__dirname, 'fixtures-dirty', 'schema-v1.db')));
+        done();
+    });
     after(function(done) {
         try { fs.unlinkSync(path.join(tmppath, 'app.db')); } catch(err) {}
+        try { fs.unlinkSync(path.join(tmppath, 'noncompact.db')); } catch(err) {}
+        try { fs.unlinkSync(path.join(tmppath, 'schema-v1.db')); } catch(err) {} 
         try { fs.unlinkSync(path.join(tmppath, 'cache', 'font-dbad83a6.png')); } catch(err) {}
         try { fs.rmdirSync(path.join(tmppath, 'cache')); } catch(err) {}
         try { fs.rmdirSync(tmppath); } catch(err) {}
         done();
+    });
+
+    it('migrates', function(done) {
+        var dbpath = path.join(tmppath, 'schema-v1.db');
+        var db = dirty(dbpath);
+        db.once('load', function() {
+            var docs = {};
+            tm.dbmigrate(db);
+            db.forEach(function(k,v) { docs[k] = v });
+            assert.deepEqual({
+                version: 2,
+                history: {
+                    style: [ 'tmstyle:///no-protocol/path/style.tm2' ],
+                    source: [ 'mapbox:///mapbox.mapbox-streets-v2' ]
+                }
+            }, docs);
+            done();
+        });
+    });
+
+    it('compacts', function(done) {
+        var dbpath = path.join(tmppath, 'noncompact.db');
+        assert.equal(276, fs.statSync(dbpath).size);
+        tm.dbcompact(dbpath, function(err, db) {
+            assert.ifError(err);
+            db.on('drain', function() {
+                assert.equal(23, fs.statSync(dbpath).size);
+                done();
+            });
+        });
     });
 
     it('sortkeys', function() {


### PR DESCRIPTION
Splits out `node-dirty` db compaction + migrations with tests.

Should chip away a bit at https://github.com/mapbox/tm2/issues/315
