### PR TITLE
Add error modal to clean up error styling. Refs #257.

### DIFF
--- a/app/source.js
+++ b/app/source.js
@@ -260,7 +260,7 @@ Editor.prototype.addlayer = function(ev) {
     $('#layers .js-menu-content').sortable('destroy').sortable();
 
   } else {
-    Modal.show('message', 'Layer name must be different from existing layer "' + values.id + '"');
+    Modal.show('error', 'Layer name must be different from existing layer "' + values.id + '"');
   }
   return false;
 };
@@ -281,9 +281,9 @@ Editor.prototype.error = function(model, resp) {
   if (resp.responseText) {
     var json;
     try { json = JSON.parse(resp.responseText); } catch(err) {}
-    Modal.show('message', json ? json.message : resp.responseText);
+    Modal.show('error', json ? json.message : resp.responseText);
   } else {
-    Modal.show('message', 'Could not save source "' + model.id + '"');
+    Modal.show('error', 'Could not save source "' + model.id + '"');
   }
 };
 Editor.prototype.save = function(ev, options) {

--- a/app/style.js
+++ b/app/style.js
@@ -323,7 +323,7 @@ Editor.prototype.addtab = function(ev) {
     $('.carto-tabs').append("<a rel='"+filename+"' href='#code-"+filename.replace(/[^\w+]/g,'_')+"' class='strong quiet tab js-tab round pad0y pad1x truncate'>"+filename.replace(/.mss/,'')+" <span class='icon trash js-deltab pin-topright round pad1'></span></a><!--");
     code[filename] = Tab(filename, '');
   } else {
-    Modal.show('message', 'Tab name must be different than existing tab "' + filename.replace(/.mss/,'') + '"');
+    Modal.show('error', 'Tab name must be different than existing tab "' + filename.replace(/.mss/,'') + '"');
     field.val('');
     return false;
   }
@@ -415,7 +415,7 @@ Editor.prototype.error = function(model, resp) {
   this.messageclear();
 
   if (!resp.responseText)
-    return Modal.show('message', 'Could not save style "' + model.id + '"');
+    return Modal.show('error', 'Could not save style "' + model.id + '"');
 
     // Assume carto.js specific error array format response.
   _(JSON.parse(resp.responseText).message.toString().split('\n')).chain()
@@ -429,7 +429,7 @@ Editor.prototype.error = function(model, resp) {
         code[id]._cartoErrors.push(ln);
         code[id].setGutterMarker(ln, 'errors', this.cartoError(ln, e));
       } else {
-        return Modal.show('message', e);
+        return Modal.show('error', e);
       }
     }).bind(this));
 };
@@ -467,7 +467,7 @@ Editor.prototype.upload = function(ev) {
     })
     .error(function(resp) {
       $('.settings-body').removeClass('loading');
-      return Modal.show('message', resp.responseText);
+      return Modal.show('error', resp.responseText);
     });
 };
 

--- a/app/test/app.test.js
+++ b/app/test/app.test.js
@@ -121,8 +121,8 @@ describe('#style-ui', function() {
         $('#addtab-filename').val('baz');
         $('#addtab').submit();
 
-        assert.ok(hasModal('#message'));
-        assert.equal('Tab name must be different than existing tab "baz"', $('#message > div').text());
+        assert.ok(hasModal('#error'));
+        assert.equal('Tab name must be different than existing tab "baz"', $('#error > pre').text());
     });
 });
 

--- a/templates/modalerror._
+++ b/templates/modalerror._
@@ -1,0 +1,5 @@
+<form id='message' class='modal round col6 margin3 pin-top top2 fill-light'>
+  <a class='pad1 quiet icon x pin-topright close'></a>
+  <h3 class='pad1y pad2x row1 keyline-bottom center'>Error</h3>
+  <pre class='pad1y pad2x'><%=obj%></pre>
+</form>

--- a/templates/modalerror._
+++ b/templates/modalerror._
@@ -1,4 +1,4 @@
-<form id='message' class='modal round col6 margin3 pin-top top2 fill-light'>
+<form id='error' class='modal round col6 margin3 pin-top top2 fill-light'>
   <a class='pad1 quiet icon x pin-topright close'></a>
   <h3 class='pad1y pad2x row1 keyline-bottom center'>Error</h3>
   <pre class='pad1y pad2x'><%=obj%></pre>

--- a/templates/source._
+++ b/templates/source._
@@ -229,6 +229,7 @@ templates.modalbrowsersave = <%= this.modalbrowsersave.source %>;
 templates.modalbrowseropen = <%= this.modalbrowseropen.source %>;
 templates.modaladdlayer = <%= this.modaladdlayer.source %>;
 templates.modalmessage = <%= this.modalmessage.source %>;
+templates.modalerror = <%= this.modalerror.source %>;
 templates.layeritem = <%= this.layeritem.source %>;
 templates.layerconf = <%= this.layerconf.source %>;
 templates.layerfields = <%= this.layerfields.source %>;

--- a/templates/style._
+++ b/templates/style._
@@ -382,6 +382,7 @@ templates.modalbrowseropen = <%= this.modalbrowseropen.source %>;
 templates.modaladdtab = <%= this.modaladdtab.source %>;
 templates.modalmessage = <%= this.modalmessage.source %>;
 templates.modalsources = <%= this.modalsources.source %>;
+templates.modalerror = <%= this.modalerror.source %>;
 templates.sourceitem = <%= this.sourceitem.source %>;
 templates.sourcelayers = <%= this.sourcelayers.source %>;
 templates.xraycolor = <%= this.xraycolor.source %>;


### PR DESCRIPTION
Adds error-specific modal that uses `<pre>` for error text.
