### PR TITLE
No vt fields

### DIFF
--- a/templates/layercsv.html
+++ b/templates/layercsv.html
@@ -42,5 +42,5 @@
     </fieldset>
   </div>
 
-  <div class='fields'><%= this.layerfields(obj.vt.fields) %></div>
+  <div class='fields'><%= this.layerfields(obj.fields) %></div>
 </form>

--- a/templates/layergeojson.html
+++ b/templates/layergeojson.html
@@ -41,5 +41,5 @@
     </fieldset>
   </div>
 
-  <div class='fields'><%= this.layerfields(obj.vt.fields) %></div>
+  <div class='fields'><%= this.layerfields(obj.fields) %></div>
 </form>

--- a/templates/layerogr.html
+++ b/templates/layerogr.html
@@ -42,5 +42,5 @@
     </fieldset>
   </div>
 
-  <div class='fields'><%= this.layerfields(obj.vt.fields) %></div>
+  <div class='fields'><%= this.layerfields(obj.fields) %></div>
 </form>

--- a/templates/layerpostgis.html
+++ b/templates/layerpostgis.html
@@ -65,7 +65,7 @@
       </section>
     </fieldset>
   </div>
-  <div class='fields'><%= this.layerfields(obj.vt.fields) %></div>
+  <div class='fields'><%= this.layerfields(obj.fields) %></div>
 
   <div class='sql'>
     <section class='pad1'>

--- a/templates/layershape.html
+++ b/templates/layershape.html
@@ -42,5 +42,5 @@
     </fieldset>
   </div>
 
-  <div class='fields'><%= this.layerfields(obj.vt.fields) %></div>
+  <div class='fields'><%= this.layerfields(obj.fields) %></div>
 </form>

--- a/templates/layersqlite.html
+++ b/templates/layersqlite.html
@@ -49,7 +49,7 @@
     </fieldset>
   </div>
 
-  <div class='fields'><%= this.layerfields(obj.vt.fields) %></div>
+  <div class='fields'><%= this.layerfields(obj.fields) %></div>
 
 
   <div class='sql'>

--- a/templates/source.html
+++ b/templates/source.html
@@ -217,7 +217,7 @@ revlayers.reverse();
     var type = (l.Datasource && l.Datasource.type);
     if (this['layer' + type]) print(this['layer' + type](_({
         tm: tm,
-        vt: source.vector_layers.filter(function(v) { return v.id === l.id })[0]
+        fields: source.vector_layers.filter(function(v) { return v.id === l.id })[0].fields
     }).extend(l)));
   }.bind(this));
 } %>


### PR DESCRIPTION
Removes the weird expectation in templates that fields are attached to a nested vt object. I could not find a good reason why this was the case.

Should enable use of templating data directly off of `Layer#get()` without any extra munging.

cc @GretaCB 
