### PR TITLE
Fix search

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -666,6 +666,9 @@ fieldset section.keyline-bottom { border-bottom-color:rgba(0,0,0,.2) !important;
 .CodeMirror .CodeMirror-dialog { top:-40px; }
 .CodeMirror .hidden:target { display:block; }
 
+.CodeMirror #search-info ~ .dialog-y,
+.CodeMirror #search-info:target ~ .dialog-n { display: none;}
+.CodeMirror #search-info:target ~ .dialog-y { display: block;}
 /* CodeMirror Addon: palette swatch */
 .CodeMirror .cm-palette-hint {
   display:inline-block;

--- a/app/app.css
+++ b/app/app.css
@@ -663,19 +663,8 @@ fieldset section.keyline-bottom { border-bottom-color:rgba(0,0,0,.2) !important;
 .CodeMirror-dialog * {
   box-sizing:border-box;
   }
-.CodeMirror .CodeMirror-dialog {
-  background:white;
-  border-bottom:1px solid #eee;
-  position:absolute;
-  top:-40px;left:0;right:0;
-  z-index:100;
-  }
-.CodeMirror-dialog input {
-  background:transparent;
-  border:none;
-  outline:none;
-  }
-  .CodeMirror .hidden:target { display:block; }
+.CodeMirror .CodeMirror-dialog { top:-40px; }
+.CodeMirror .hidden:target { display:block; }
 
 /* CodeMirror Addon: palette swatch */
 .CodeMirror .cm-palette-hint {

--- a/app/app.css
+++ b/app/app.css
@@ -607,6 +607,7 @@ fieldset section.keyline-bottom { border-bottom-color:rgba(0,0,0,.2) !important;
   top:40px; bottom:0;
   width:100%; height:auto;
   visibility:hidden;
+  overflow: visible;
   }
 .CodeMirror.active { visibility:visible; }
 .CodeMirror .CodeMirror-vscrollbar { overflow-y: hidden;}
@@ -660,33 +661,14 @@ fieldset section.keyline-bottom { border-bottom-color:rgba(0,0,0,.2) !important;
 /* CodeMirror Addon: Search Dialog */
 .CodeMirror-dialog,
 .CodeMirror-dialog * {
-  font:15px/20px 'Open Sans', sans-serif;
-  -webkit-box-sizing:border-box;
-     -moz-box-sizing:border-box;
-          box-sizing:border-box;
+  box-sizing:border-box;
   }
-  .CodeMirror-dialog {
-    box-shadow:inset 0 1px 1px rgba(0,0,0,0.1);
-    }
-  .CodeMirror-dialog .small,
-  .CodeMirror-dialog .small *,
-  .CodeMirror-dialog small,
-  .CodeMirror-dialog button,
-  .CodeMirror-dialog label {
-    font-size:12px;
-    line-height:20px;
-    }
-  .CodeMirror-dialog button,
-  .CodeMirror-dialog label {
-    font-family:'Open Sans Bold', sans-serif;
-    }
 .CodeMirror .CodeMirror-dialog {
   background:white;
   border-bottom:1px solid #eee;
   position:absolute;
-  top:0;left:0;right:0;
+  top:-40px;left:0;right:0;
   z-index:100;
-  padding:0;
   }
 .CodeMirror-dialog input {
   background:transparent;

--- a/app/codemirror.tm2.search.js
+++ b/app/codemirror.tm2.search.js
@@ -116,10 +116,6 @@
         return cm.getSearchCursor(query, pos, queryCaseInsensitive(query));
     }
 
-    function dialog(cm, text, f) {
-        cm.openDialog(text, f);
-    }
-
     function parseQuery(query) {
         var isRE = query.match(/^\/(.*)\/([a-z]*)$/);
         if (isRE) {
@@ -148,7 +144,7 @@
     function doSearch(cm, rev) {
         var state = getSearchState(cm);
         if (state.query) return findNext(cm, rev);
-        dialog(cm, queryDialog, function (query) {
+        cm.openDialog(queryDialog, function (query) {
             cm.operation(function () {
                 if (state.query && state.query !== query) state.query = query;
                 state.query = parseQuery(query);

--- a/app/codemirror.tm2.search.js
+++ b/app/codemirror.tm2.search.js
@@ -185,22 +185,20 @@
         return query;
     }
 
-    var infoText = '<div id="search-info" class="clearfix keyline-bottom keyline-top small fill-white search-info hidden">'+
-    '<div class="pad1x pad0y quiet">You can use /re/ syntax for regex search</div>'+
-    '<div class="clearfix col12">'+
-        '<label class="col12 pad1x pad0y keyline-bottom">Keyboard Commands</label>'+
-        '<div class="pad1 keyline-right col6">'+
+    var infoText = '<div id="search-info" class="clearfix keyline-top small fill-white search-info hidden">'+
+        '<div class="pad1 col6">'+
           '<span class="code inline"><kbd class="prefixed">F</kbd> Find</span><br/>'+
           '<span class="code inline"><kbd class="prefixed">G</kbd> Next result</span><br />'+
           '<span class="code inline"><kbd class="prefixed">Shift+G</kbd> Previous result</span>'+
         '</div>' +
         '<div class="pad1 col6">'+
           '<span class="code inline"><kbd class="prefixed">Alt+F</kbd> Find & replace all</span>'+
+          '<div class="quiet">use /re/ syntax for regex search.</div>'+
         '</div>' +
-    '</div>' +
     '</div>';
-    var infoAndClose = "<div class='pin-right pad1'><a href='#search-info' id='dialog-info' class='inline icon info quiet'></a><a href='#' id='dialog-close' class='inline icon x quiet'></a></div>";
-    var queryDialog = "<fieldset class='with-icon'><span class='icon search'></span><input type='text' value='' class='stretch'></fieldset>" + infoAndClose + infoText;
+    var infoAndClose = "<a href='#search-info' id='dialog-info' class='pin-left pad1 inline icon info quiet'></a><a href='#' id='dialog-close' class='pin-right pad1 inline icon x quiet'></a></div>";
+    var queryButton = "<div class='pin-topright pad0y'><a href='#' class='button short icon small quiet search'>Search</a></div>"
+    var queryDialog = "<div class='fill-white z10 pad4x'><fieldset class='keyline-left contain'><input type='text' value='' class='stretch'>" + queryButton + "</fieldset></div>" + infoAndClose + infoText;
 
     function doSearch(cm, rev) {
         var state = getSearchState(cm);

--- a/app/codemirror.tm2.search.js
+++ b/app/codemirror.tm2.search.js
@@ -72,12 +72,12 @@
                 if (options && options.onKeyDown) {
                     return;
                 }
-                if (e.keyCode == 13 || e.keyCode == 27) {
+                if (e.keyCode === 13 || e.keyCode === 27 || (e.keyCode === 71 && e.metaKey) || (e.keyCode === 70 && e.metaKey)) {
                     inp.blur();
                     CodeMirror.e_stop(e);
                     me.focus();
-                    if (e.keyCode == 27) close();               // ESC
-                    if (e.keyCode == 13) callback(inp.value);   // ENTER
+                    if (e.keyCode === 27) close();  // ESC
+                    if (e.keyCode === 13 || (e.keyCode === 71 && e.metaKey) || (e.keyCode === 70 && e.metaKey)) callback(inp.value); // ENTER OR CMD+G
                 }
             });
             if (options && options.onKeyUp) {

--- a/app/codemirror.tm2.search.js
+++ b/app/codemirror.tm2.search.js
@@ -133,17 +133,17 @@
 
     var infoText = '<div id="search-info" class="clearfix keyline-top small fill-white search-info hidden">'+
         '<div class="pad1 col6">'+
-          '<span class="code inline"><kbd class="prefixed">F</kbd> Find</span><br/>'+
-          '<span class="code inline"><kbd class="prefixed">G</kbd> Next result</span><br />'+
-          '<span class="code inline"><kbd class="prefixed">Shift+G</kbd> Previous result</span>'+
+          '<div class="code"><kbd class="prefixed">F</kbd> Find</div>'+
+          '<div class="code"><kbd class="prefixed">G</kbd> Next result</div>'+
         '</div>' +
         '<div class="pad1 col6">'+
           '<div class="quiet">use /re/ syntax for regex search.</div>'+
+          '<div class="code"><kbd class="prefixed">Shift+G</kbd> Previous result</div>'+
         '</div>' +
     '</div>';
-    var infoAndClose = "<a href='#search-info' class='js-cm-dialog-info pin-left pad1 inline icon info quiet'></a><a href='#' id='js-cm-dialog-close' class='js-cm-dialog-close pin-right pad1 inline icon x quiet'></a></div>";
+    var infoAndClose = "<a href='#search-info' class='js-cm-dialog-info pin-topleft pad1 inline icon info quiet dialog-n'></a><a href='#' class='js-cm-dialog-info pin-topleft pad1 inline icon info fill-darken2 dark dialog-y'></a><a href='#' id='js-cm-dialog-close' class='js-cm-dialog-close pin-right pad1 inline icon x quiet'></a></div>";
     var queryButton = "<div class='pin-topright pad0y'><a href='#' class='js-cm-search-button button short icon small quiet search'>Find</a></div>"
-    var queryDialog = "<div class='fill-white z10 pad4x'><fieldset class='keyline-left contain'><input type='text' placeholder='Search stylesheet' value='' class='js-search-input clean stretch'>" + queryButton + "</fieldset></div>" + infoAndClose + infoText;
+    var queryDialog = "<div class='fill-white z10 pad4x'><fieldset class='keyline-left contain'><input type='text' placeholder='Search stylesheet' value='' class='js-search-input clean stretch'>" + queryButton + "</fieldset></div>" + infoText + infoAndClose;
 
     function doSearch(cm, rev) {
         var state = getSearchState(cm);

--- a/templates/style.html
+++ b/templates/style.html
@@ -298,9 +298,9 @@
   <div id='code' class='z1 pin-left col12'>
   <div class='row1 fill-light pin-top'>
     <div class='pin-topleft z1 row1'><!--
-    --><a title='Documentation' class='pad1 inline quiet docs-n icon help unround align-middle fill-darken0 keyline-right' href='#docs'></a><!--
+    --><a title='Documentation' class='pad1 inline quiet docs-n icon help unround align-middle keyline-right' href='#docs'></a><!--
       --><a title='Documentation' class='pad1 inline dark docs-y icon help unround align-middle fill-darken2 keyline-right' href='#'></a><!--
-      --><a title='Data layers' class='pad1 inline quiet layers-n icon point-line align-middle fill-darken0 keyline-right' href='#layers'></a><!--
+      --><a title='Data layers' class='pad1 inline quiet layers-n icon point-line align-middle keyline-right' href='#layers'></a><!--
       --><a title='Data layers' class='pad1 inline dark layers-y icon point-line unround align-middle fill-darken2 keyline-right' href='#'></a>
     </div>
     <nav id='tabs' class='keyline-left row1 keyline-bottom pad0y pin-top fill-darken0 contain small'>


### PR DESCRIPTION
Search bar behaves more like how user would expect. From https://github.com/mapbox/tm2/issues/191, I hit these:
- [x] cmd+f when search is already open should not open browser search.
- [x] Allow user to create a new search based on old search. Right now if a search is in, no way to reset it and start a new search.
- [x] cmd+g only works after search has been started. Cannot start a search with cmd+g.
- [x] Clarify that user must press 'return' to view results. A 'go' button will solve this problem.
- [x] Allow user to press escape to dismiss search UI (currently only works if input is active)
- [x] Do not obscure code with search bar
- [x] When dismissing search, remove all highlights in code.

There are a couple things I didn't do, like dismissing search from tab when switching tabs, and informing user of number of search results or if search result failed.

Would prefer to get this merged them tackle the unfinished points later.

This PR also removes find/replace. It was confusing/unusable in it's prior state.
