### PR TITLE
Scope eol

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/expected/ eol=lf


### PR DESCRIPTION
This should solve #445 but I can't confirm that until appveyor builds get fixed. But we need to get the un-scoped .getattributes out of our lives in the meantime.
