### PR TITLE
Updated for windows testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,17 @@
 environment:
   matrix:
-    - nodejs_version: 0.10
+#    - nodejs_version: 0.10
+    - nodejs_version: 0.11
 
 platform:
   - x86
+
+matrix:
+  allow_failures:
+    - platform: x86
+      nodejs_version: 0.10
+    - platform: x86
+      nodejs_version: 0.11
 
 install:
   - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
@@ -11,9 +19,7 @@ install:
   - node -e "console.log(process.version)"
   - node -e "console.log(process.arch)"
   - npm --version
-  - SET PATH=c:\python27;%PATH%
-  - SET PATH=C:\Program Files (x86)\MSBuild\12.0\bin\;%PATH%
-  - npm install --msvs_version=2013
+  - npm install
   - npm test
 
 build: OFF

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,9 @@
 environment:
   matrix:
-#    - nodejs_version: 0.10
     - nodejs_version: 0.11
 
 platform:
   - x86
-
-matrix:
-  allow_failures:
-    - platform: x86
-      nodejs_version: 0.10
-    - platform: x86
-      nodejs_version: 0.11
 
 install:
   - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
@@ -23,9 +15,6 @@ install:
   - npm test
 
 build: OFF
-
 test: OFF
-
 test_script: OFF
-
 deploy: OFF

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "request": "~2.36.0",
     "mapbox-upload": "0.0.2",
     "mapnik-omnivore": "https://github.com/mapbox/mapnik-omnivore/tarball/master",
-    "abaculus": "https://github.com/mapbox/abaculus/tarball/node-mapnik-blend"
+    "abaculus": "https://github.com/mapbox/abaculus/tarball/master"
   },
   "devDependencies": {
     "mocha": "1.17.x",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "js-yaml": "https://github.com/mapbox/js-yaml/tarball/scalar-styles",
     "fstream": "0.1.x",
     "tar": "0.1.x",
-    "mapnik": "https://github.com/mapnik/node-mapnik/tarball/master",
+    "mapnik": "~1.4.8",
     "mapnik-reference": "~5.0.8",
     "carto": "0.11.0",
     "tilelive": "4.5.x",
@@ -38,7 +38,7 @@
     "request": "~2.36.0",
     "mapbox-upload": "0.0.2",
     "mapnik-omnivore": "1.1.1",
-    "abaculus": "0.0.3"
+    "abaculus": "https://github.com/mapbox/abaculus/tarball/node-mapnik-blend"
   },
   "devDependencies": {
     "mocha": "1.17.x",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "js-yaml": "https://github.com/mapbox/js-yaml/tarball/scalar-styles",
     "fstream": "0.1.x",
     "tar": "0.1.x",
-    "mapnik": "~1.4.8",
+    "mapnik": "~1.4.9",
     "mapnik-reference": "~5.0.8",
     "carto": "0.11.0",
     "tilelive": "4.5.x",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "minimist": "0.1.x",
     "underscore": "1.4.x",
     "tilejson": "0.7.0",
+    "sqlite3": "https://github.com/mapbox/node-sqlite3/tarball/master",
     "mbtiles": "0.4.x",
     "mkdirp": "0.5.x",
     "dirty": "0.9.9",
@@ -37,7 +38,7 @@
     "cors": "~2.3.1",
     "request": "~2.36.0",
     "mapbox-upload": "0.0.2",
-    "mapnik-omnivore": "1.1.1",
+    "mapnik-omnivore": "https://github.com/mapbox/mapnik-omnivore/tarball/master",
     "abaculus": "https://github.com/mapbox/abaculus/tarball/node-mapnik-blend"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "js-yaml": "https://github.com/mapbox/js-yaml/tarball/scalar-styles",
     "fstream": "0.1.x",
     "tar": "0.1.x",
-    "mapnik": "~1.4.6",
+    "mapnik": "https://github.com/mapnik/node-mapnik/tarball/master",
     "mapnik-reference": "~5.0.8",
     "carto": "0.11.0",
     "tilelive": "4.5.x",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "js-yaml": "https://github.com/mapbox/js-yaml/tarball/scalar-styles",
     "fstream": "0.1.x",
     "tar": "0.1.x",
-    "mapnik": "~1.4.9",
+    "mapnik": "~1.4.10",
     "mapnik-reference": "~5.0.8",
     "carto": "0.11.0",
     "tilelive": "4.5.x",


### PR DESCRIPTION
This updates:
- node-mapnik
- abaculus
- mapnik-omnivore
- sqlite3

Such that tm2 can be tested against node v0.11.x. This is useful because on appveyor only >= v0.11 is viable for correct log output. With Node v0.10.x logs will be randomly truncated which hides errors.
