### PR TITLE
add max height to popup

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -603,6 +603,7 @@ a.project.proj-active .proj-status { display: block;}
   padding: 0px;
   overflow-x: hidden;
   overflow-y: auto;
+  max-height: 300px;
 }
 .leaflet-popup .leaflet-popup-content .xray-listing {
   width:240px;


### PR DESCRIPTION
Added `Max height: 300px` to marker popups. 300px is still pretty tall, so it's rare to have popup content cut off. Anything larger than this just gets unwieldy, so it's better to have scrolling content.
