### PR TITLE
tilelive validate

### DIFF
--- a/lib/source.js
+++ b/lib/source.js
@@ -168,7 +168,11 @@ source.save = function(data, callback) {
         'minzoom',
         'maxzoom'
     ]);
-    if (err) return callback(err);
+    // Exception for vector_layers length check. While sources are being
+    // edited a vector_layers array of length 0 is ok.
+    if (err && err.message !== 'vector_layers must be an array of layer objects') {
+        return callback(err);
+    }
 
     source.toXML(data, function(err, xml) {
         if (err) return callback(err);

--- a/lib/source.js
+++ b/lib/source.js
@@ -159,6 +159,17 @@ source.save = function(data, callback) {
         return callback(err);
     }
 
+    // validate key info keys.
+    var err = tilelive.verify(data, [
+        'name',
+        'description',
+        'attribution',
+        'center',
+        'minzoom',
+        'maxzoom'
+    ]);
+    if (err) return callback(err);
+
     source.toXML(data, function(err, xml) {
         if (err) return callback(err);
         if (!perm) return source.refresh(data, xml, callback);

--- a/lib/style.js
+++ b/lib/style.js
@@ -97,6 +97,21 @@ style.save = function(data, callback) {
     data = _(data).defaults(defaults);
     data._tmp = style.tmpid(id);
 
+    // validate key info keys.
+    var err = tilelive.verify(data, [
+        'name',
+        'description',
+        'attribution',
+        'source',
+        'center',
+        'bounds',
+        'minzoom',
+        'maxzoom',
+        'format',
+        'template'
+    ]);
+    if (err) return callback(err);
+
     style.toXML(data, function(err, xml) {
         if (err) return callback(err);
         if (!perm) return style.refresh(data, xml, callback);

--- a/test/source.test.js
+++ b/test/source.test.js
@@ -197,6 +197,17 @@ test('local: saves source in memory', function(t) {
     });
 });
 
+test('local: saves source (invalid)', function(t) {
+    testutil.createTmpProject('source-save', localsource, function(err, tmpid, info) {
+        assert.ifError(err);
+        source.save(_({id:'tmsource:///tmp-12345678', minzoom:-1}).defaults(info), function(err, source) {
+            assert.equal(err.toString(), 'Error: minzoom must be an integer between 0 and 22', 'source.save() errors on invalid style');
+            t.end();
+        });
+    });
+});
+
+
 test('local: saves source to disk', function(t) {
     testutil.createTmpProject('source-save', localsource, function(err, tmpid, data) {
     assert.ifError(err);

--- a/test/style.test.js
+++ b/test/style.test.js
@@ -58,6 +58,16 @@ test('saves style in memory', function(t) {
     });
 });
 
+test('saves style (invalid)', function(t) {
+    testutil.createTmpProject('style-save', localstyle, function(err, tmpid, data) {
+        t.ifError(err);
+        style.save(_({id:'tmstyle:///tmp-12345678',minzoom:-1}).defaults(data), function(err, source) {
+            assert.equal(err.toString(), 'Error: minzoom must be an integer between 0 and 22', 'style.save() errors on invalid style');
+            t.end();
+        });
+    });
+});
+
 test('saves style to disk', function(t) {
     testutil.createTmpProject('style-save', localstyle, function(err, tmpid, data) {
     t.ifError(err);


### PR DESCRIPTION
Uses upstream tilelive.verify to validate style/source properties.
