### PR TITLE
Fix minor differences from BSD 3-Clause license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,14 +4,15 @@ All rights reserved.
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-- Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice, this
-  list of conditions and the following disclaimer in the documentation and/or
-  other materials provided with the distribution.
-- Neither the name "Mapbox" nor the names of its contributors may be used to
-  endorse or promote products derived from this software without specific prior
-  written permission.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this
+   list of conditions and the following disclaimer in the documentation and/or
+   other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may 
+   be used to endorse or promote products derived from this software without 
+   specific prior written permission.
+
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED


### PR DESCRIPTION
#24 indicated that the license was BSD, but there were some minor transcription errors. Reference for text: http://opensource.org/licenses/BSD-3-Clause
