### PR TITLE
Normalize history paths

### DIFF
--- a/app/lib.js
+++ b/app/lib.js
@@ -178,9 +178,11 @@ views.Browser.prototype.submit = function(ev) {
   }, {});
   if (!values.basename) return false;
   if (!this.callback) return false;
+  var win = this.cwd.indexOf(':') === 1;
+  var sep = win ? '\\' : '/';
   this.callback(null, (values.basename[0] === '/' || values.basename[1] === ':') ?
     values.basename :
-    values.cwd + '/' + values.basename);
+    values.cwd + sep + values.basename);
   return false;
 };
 views.Browser.prototype.browse = function(ev) {

--- a/lib/tm.js
+++ b/lib/tm.js
@@ -129,6 +129,10 @@ tm.history = function(id, invalidate) {
             uri.protocol !== 'tmstyle:') {
             throw new Error('invalid id protocol ' + uri.protocol)
         }
+        // Normalize id to uri.dirname for Windows paths.
+        if (uri.protocol === 'tmsource:' || uri.protocol === 'tmstyle:') {
+            id = uri.protocol + '//' + uri.dirname;
+        }
         var update = history.filter(function(k) { return k !== id });
         if (!invalidate) update.push(id);
         if (update.join(',') !== history.join(',')) {

--- a/test/tm.test.js
+++ b/test/tm.test.js
@@ -161,6 +161,16 @@ test('tm history', function(t) {
         'Confirm invalidation');
     t.deepEqual([].concat(defaultSources).concat(['tmstyle:///foo']), tm.history('mapbox:///mapbox.mapbox-streets-v5', true),
         'Cannot invalidate default source');
+
+    // Windows path testing.
+    var sep = path.sep;
+    path.sep = '\\';
+    t.deepEqual([].concat(defaultSources).concat(['tmstyle:///foo','tmstyle://c:/Windows/Path']), tm.history('tmstyle://c:\\Windows\\Path'),
+        'Normalizes windows path');
+    t.deepEqual([].concat(defaultSources).concat(['tmstyle:///foo','tmstyle://c:/Windows/Path']), tm.history('tmstyle://C:/Windows/Path'),
+        'Normalizes drive case in windows path');
+    path.sep = sep;
+
     t.end();
 });
 


### PR DESCRIPTION
Windows: normalizes history paths so uniqueness checks work. The following paths all get normalized when being entered into history:

```
C:\some/path
c:\some\path => c:/some/path
```

Backslashey and uppercase drive paths continue to work, just aren't entered into the history array as such.
