### PR TITLE
Use rename rather than unlink for a safer dbcompact

### DIFF
--- a/lib/tm.js
+++ b/lib/tm.js
@@ -86,27 +86,38 @@ tm.dbmigrate = function(db) {
 // copying all docs into memory, deleting the old db and writing a new one
 // in its place.
 tm.dbcompact = function(filepath, callback) {
+    var olddb = {};
     fs.exists(filepath, function(exists) {
         // If the db does not exist, no need to compact.
-        if (!exists) return callback(null, dirty(filepath));
-
-        // Read the old db into memory and remove the old file.
+        return exists ? readold() : finish();
+    });
+    // Read the old db into memory.
+    function readold() {
         var old = dirty(filepath);
-        var olddb = {};
-        old.once('read_close', function() {
-            fs.unlink(filepath, function(err) {
-                if (err && err.code !== 'ENOENT') return callback(err);
-                var db = dirty(filepath);
-                for (var k in olddb) db.set(k, olddb[k]);
-                return callback(null, db);
-            });
-        });
+        old.once('read_close', compact);
         old.once('load', function() {
             old.forEach(function(k,v) { olddb[k] = v; });
             old.close();
-            if (!Object.keys(olddb).length) old.emit('read_close');
+            if (!Object.keys(olddb).length) return finish();
         });
-    });
+    }
+    // Build compacted db from old docs.
+    function compact() {
+        var db = dirty(filepath + '.compacted');
+        for (var k in olddb) db.set(k, olddb[k]);
+        db.once('write_close', swap);
+        db.once('drain', function() { db.close(); });
+    }
+    // Rename compacted db over old db.
+    function swap() {
+        fs.rename(filepath + '.compacted', filepath, function(err) {
+            if (err) return callback(err);
+            return finish();
+        });
+    }
+    function finish() {
+        return callback(null, dirty(filepath));
+    }
 };
 
 // Set or remove a project id from recent history.

--- a/test/tm.test.js
+++ b/test/tm.test.js
@@ -65,10 +65,8 @@ test('tm compacts', function(t) {
     t.equal(276, fs.statSync(dbpath).size);
     tm.dbcompact(dbpath, function(err, db) {
         t.ifError(err);
-        db.on('drain', function() {
-            t.equal(23, fs.statSync(dbpath).size);
-            t.end();
-        });
+        t.equal(23, fs.statSync(dbpath).size);
+        t.end();
     });
 });
 


### PR DESCRIPTION
Much lower chance of losing data if process crashes in the middle of a compact operation.
