### PR TITLE
fix #387

### DIFF
--- a/app/style.js
+++ b/app/style.js
@@ -189,6 +189,10 @@ Editor.prototype.togglePane = function(name) {
 };
 
 Editor.prototype.messageclear = function() {
+  // Remove top notice
+  $('.js-error-alert').remove();
+
+  // Remove line notice
   _(code).each(function(cm) {
       _(cm._cartoErrors||[]).each(function() {
         cm.clearGutter('errors');
@@ -371,7 +375,7 @@ Editor.prototype.cartoError = function(ln, e) {
 
     if (!$('.js-error-alert').length) {
       var alert = document.createElement('div');
-      alert.className = 'z100 top1 truncate js-error-alert error-alert pin-top col12 pad1 fill-yellow';
+      alert.className = 'z100 truncate code small js-error-alert error-alert pin-bottom col12 pad0 fill-yellow';
       alert.innerHTML = '<strong>Unable to save.</strong> Fix Carto errors and try again.';
       document.getElementById('style-ui').appendChild(alert);
     }
@@ -427,7 +431,6 @@ Editor.prototype.refresh = function(ev) {
   this.messageclear();
   $('#full').removeClass('loading');
   $('body').removeClass('changed');
-  $('.js-error-alert').remove();
 
   if (!map) {
     map = L.mapbox.map('map');

--- a/app/style.js
+++ b/app/style.js
@@ -372,7 +372,7 @@ Editor.prototype.cartoError = function(ln, e) {
     if (!$('.js-error-alert').length) {
       var alert = document.createElement('div');
       alert.className = 'z100 top1 truncate js-error-alert error-alert pin-top col12 pad1 fill-yellow';
-      alert.innerHTML = '<strong>Unable to save.</strong> Fix carto errors and try again.';
+      alert.innerHTML = '<strong>Unable to save.</strong> Fix Carto errors and try again.';
       document.getElementById('style-ui').appendChild(alert);
     }
 

--- a/app/style.js
+++ b/app/style.js
@@ -369,6 +369,13 @@ Editor.prototype.cartoError = function(ln, e) {
     var error = document.createElement('div');
     error.className = 'error';
 
+    if (!$('.js-error-alert').length) {
+      var alert = document.createElement('div');
+      alert.className = 'z100 top1 truncate js-error-alert error-alert pin-top col12 pad1 fill-yellow';
+      alert.innerHTML = '<strong>Unable to save.</strong> Fix carto errors and try again.';
+      document.getElementById('style-ui').appendChild(alert);
+    }
+
     var link = document.createElement('a');
     link.id = 'error-' + ln;
     link.href = '#error-' + ln;
@@ -420,6 +427,7 @@ Editor.prototype.refresh = function(ev) {
   this.messageclear();
   $('#full').removeClass('loading');
   $('body').removeClass('changed');
+  $('.js-error-alert').remove();
 
   if (!map) {
     map = L.mapbox.map('map');

--- a/app/style.js
+++ b/app/style.js
@@ -189,10 +189,10 @@ Editor.prototype.togglePane = function(name) {
 };
 
 Editor.prototype.messageclear = function() {
-  // Remove top notice
+  // Remove bottom alert
   $('.js-error-alert').remove();
 
-  // Remove line notice
+  // Remove line alert
   _(code).each(function(cm) {
       _(cm._cartoErrors||[]).each(function() {
         cm.clearGutter('errors');


### PR DESCRIPTION
Line-based error messages seem to appear on the wrong line often, and are sometimes offscreen. What seems like a save may not have been. How about just doing this for all errors:

![screen shot 2014-08-19 at 6 24 31 pm](https://cloud.githubusercontent.com/assets/108094/3974226/8ec4ee00-27f1-11e4-9266-df4d8f6765de.png)
