### PR TITLE
Update conf path

### DIFF
--- a/lib/tm.js
+++ b/lib/tm.js
@@ -19,10 +19,10 @@ var tm = {};
 // Set or get config.
 tm.db;
 tm._config = {
-    db: path.join(process.env.HOME, '.tilemill', 'v2', 'app.db'),
-    tmp: path.join(process.env.HOME, '.tilemill', 'v2', 'tmp'),
-    cache: path.join(process.env.HOME, '.tilemill', 'v2', 'cache'),
-    fonts: path.join(process.env.HOME, '.tilemill', 'v2', 'fonts'),
+    db: path.join(process.env.HOME, '.mapbox-studio', 'app.db'),
+    tmp: path.join(process.env.HOME, '.mapbox-studio', 'tmp'),
+    cache: path.join(process.env.HOME, '.mapbox-studio', 'cache'),
+    fonts: path.join(process.env.HOME, '.mapbox-studio', 'fonts'),
     mapboxauth: 'https://api.mapbox.com',
     mapboxtile: 'https://a.tiles.mapbox.com/v4'
 };


### PR DESCRIPTION
Use `~/.mapbox-studio` rather than `~/.tilemill/v2`.

Will cause a little conf reset action for folks but better now than later.
