### PR TITLE
Simplify post-test cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "queue-async": "1.0.x",
+    "rimraf": "2.2.x",
     "getport": "0.1.x",
     "express": "3.1.x",
     "passport": "0.2.x",
@@ -56,6 +57,7 @@
   "scripts": {
     "start": "./index.js",
     "preinstall": "node scripts/run.js scripts/vendor-node.sh",
-    "test": "tape test/*.test.js"
+    "test": "tape test/*.test.js",
+    "posttest": "node test/cleanup.js"
   }
 }

--- a/test/cleanup.js
+++ b/test/cleanup.js
@@ -1,0 +1,7 @@
+var rimraf = require('rimraf');
+var tm = require('../lib/tm');
+
+rimraf(tm.join(require('os').tmpdir(), 'mapbox-studio'), function(err) {
+    if (err) throw err;
+    process.exit(0);
+});

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -12,10 +12,8 @@ var middleware = require('../lib/middleware');
 var style = require('../lib/style');
 var source = require('../lib/source');
 var mockOauth = require('../lib/mapbox-mock')(require('express')());
-var tmp = os.tmpdir();
-var tmppath = tm.join(tmp, 'tm2-middleware-' + (+new Date));
-
-var tmpId = tm.join(tmp, 'tm2-middlewareProject-' + (+new Date));
+var tmppath = tm.join(os.tmpdir(), 'mapbox-studio', 'middleware-' + (+new Date));
+var tmpId = tm.join(os.tmpdir(), 'mapbox-studio', 'middlewareProject-' + (+new Date));
 var sourceId = 'tmsource://' + tm.join(path.resolve(__dirname), 'fixtures-localsource');
 var styleId = 'tmstyle://' + tm.join(path.resolve(__dirname), 'fixtures-localsource');
 var server;
@@ -125,16 +123,6 @@ test('writeStyle: makes persistent styles', function(t) {
         t.equal(data.styles['a.mss'], fs.readFileSync(tmpId + '/a.mss', 'utf8'), 'saves a.mss');
         t.end();
     });
-});
-
-test('writeStyle: cleanup', function(t) {
-    setTimeout(function() {
-        ['project.xml','project.yml','a.mss','.thumb.png'].forEach(function(file) {
-            try { fs.unlinkSync(path.join(tmpId,file)) } catch(err) {};
-        });
-        try { fs.rmdirSync(tmpId) } catch(err) {};
-        t.end();
-    }, 250);
 });
 
 test('loadStyle: loads a tmp style', function(t) {
@@ -252,16 +240,6 @@ test('writeSource: makes persistent sources', function(t) {
     });
 });
 
-test('writeSource: cleanup', function(t) {
-    setTimeout(function() {
-        ['data.xml', 'data.yml'].forEach(function(file) {
-            try { fs.unlinkSync(path.join(tmpId,file)) } catch(err) {};
-        });
-        try { fs.rmdirSync(tmpId) } catch(err) {};
-        t.end();
-    }, 250);
-});
-
 test('loadSource: loads a tmp source', function(t) {
     var writeReq = { body: {} };
     var req = { query: { id: source.tmpid() } };
@@ -367,10 +345,5 @@ test('cleanup', function(t) {
     tm.db.rm('oauth');
     tm.history(sourceId, true);
     tm.history(styleId, true);
-    try { fs.unlinkSync(path.join(tmppath, 'app.db')); } catch(err) {}
-    try { fs.rmdirSync(path.join(tmppath, 'cache')); } catch(err) {}
-    try { fs.rmdirSync(tmppath); } catch(err) {}
-    server.close(function() {
-        t.end();
-    });
+    server.close(function() { t.end(); });
 });

--- a/test/source.test.js
+++ b/test/source.test.js
@@ -14,12 +14,12 @@ var creds = {
     account: 'test',
     accesstoken: 'testaccesstoken'
 };
-var tmp = require('os').tmpdir();
+var tmp = tm.join(require('os').tmpdir(),'mapbox-studio');
 var UPDATE = !!process.env.UPDATE;
 var server;
 
 var localsource = 'tmsource://' + path.join(__dirname,'fixtures-localsource');
-var tmppath = path.join(tmp, 'tm2-sourceTest-' + +new Date);
+var tmppath = tm.join(tmp, 'sourceTest-' + +new Date);
 
 test('setup: config', function(t) {
     tm.config({
@@ -486,12 +486,5 @@ test('source.mbtilesUpload: does not allow redundant upload', function(t) {
 });
 
 test('cleanup', function(t) {
-    testutil.cleanup();
-    try { fs.unlinkSync(path.join(tmppath, 'app.db')); } catch(err) {}
-    try { fs.rmdirSync(path.join(tmppath, 'cache')); } catch(err) {}
-    try { fs.rmdirSync(path.join(tmppath, 'tmp')); } catch(err) {}
-    try { fs.rmdirSync(tmppath); } catch(err) {}
-    server.close(function() {
-        t.end();
-    });
+    server.close(function() { t.end(); });
 });

--- a/test/style.test.js
+++ b/test/style.test.js
@@ -12,7 +12,7 @@ var mockOauth = require('../lib/mapbox-mock')(require('express')());
 var Vector = require('tilelive-vector');
 var testutil = require('./util');
 var UPDATE = !!process.env.UPDATE;
-var tmp = require('os').tmpdir();
+var tmp = tm.join(require('os').tmpdir(), 'mapbox-studio');
 var creds = {
     account: 'test',
     accesstoken: 'testaccesstoken'
@@ -20,7 +20,7 @@ var creds = {
 
 var server;
 var localstyle = 'tmstyle://' + tm.join(__dirname, 'fixtures-localstyle');
-var tmppath = tm.join(tmp, 'tm2-styleTest-' + (+new Date));
+var tmppath = tm.join(tmp, 'styleTest-' + (+new Date));
 
 test('setup: config', function(t) {
     tm.config({
@@ -333,12 +333,6 @@ test('style.upload: errors on unsaved id', function(t) {
 });
 
 test('cleanup', function(t) {
-    testutil.cleanup();
-    try { fs.unlinkSync(path.join(tmppath, 'app.db')); } catch(err) {}
-    try { fs.rmdirSync(path.join(tmppath, 'cache')); } catch(err) {}
-    try { fs.rmdirSync(tmppath); } catch(err) {}
-    server.close(function() {
-        t.end();
-    });
+    server.close(function() { t.end(); });
 });
 

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -76,17 +76,7 @@ function ready(err) {
         return !only || t.name === only;
     });
     function runTest() {
-        if (!tests.length) {
-            testutil.cleanup();
-            try { fs.unlinkSync(path.join(tmp, 'app.db')); } catch(err) {}
-            try { fs.rmdirSync(path.join(tmp, 'tmp')); } catch(err) {}
-            try { fs.rmdirSync(path.join(tmp, 'cache')); } catch(err) {}
-            try { fs.rmdirSync(tmp); } catch(err) {}
-            setTimeout(function() {
-                process.exit(exit);
-            }, 1000);
-            return;
-        }
+        if (!tests.length) process.exit(exit);
         var test = tests.shift();
         testutil.createTmpProject(test.name, test.src, function(err, tmpid) {
             if (err) throw err;

--- a/test/tm.test.js
+++ b/test/tm.test.js
@@ -4,7 +4,7 @@ var path = require('path');
 var assert = require('assert');
 var tm = require('../lib/tm');
 var dirty = require('dirty');
-var tmppath = path.join(require('os').tmpdir(), 'tm2-lib-' + +new Date);
+var tmppath = tm.join(require('os').tmpdir(), 'mapbox-studio', 'tm-' + +new Date);
 var stream = require('stream');
 var progress = require('progress-stream');
 var UPDATE = process.env.UPDATE;
@@ -289,17 +289,5 @@ test('tm copydir filter', function(t) {
         t.equal(fs.existsSync(tm.join(dest, '10m_lakes_historic.shp')), true, 'includes shp');
         t.end();
     });
-});
-
-test('cleanup', function(t) {
-    try { fs.unlinkSync(path.join(tmppath, 'app.db')); } catch(err) {}
-    try { fs.unlinkSync(path.join(tmppath, 'noncompact.db')); } catch(err) {}
-    try { fs.unlinkSync(path.join(tmppath, 'schema-v1.db')); } catch(err) {}
-    try { fs.unlinkSync(path.join(tmppath, 'schema-v2.db')); } catch(err) {}
-    try { fs.unlinkSync(path.join(tmppath, 'schema-v3.db')); } catch(err) {}
-    try { fs.unlinkSync(path.join(tmppath, 'cache', 'font-dbad83a6.png')); } catch(err) {}
-    try { fs.rmdirSync(path.join(tmppath, 'cache')); } catch(err) {}
-    try { fs.rmdirSync(tmppath); } catch(err) {}
-    t.end();
 });
 

--- a/test/util.js
+++ b/test/util.js
@@ -1,6 +1,6 @@
 var tm = require('../lib/tm');
 var fs = require('fs');
-var tmp = require('os').tmpdir();
+var tmp = tm.join(require('os').tmpdir(), 'mapbox-studio');
 var path = require('path');
 var libs = {};
 libs.style = require('../lib/style');
@@ -8,7 +8,6 @@ libs.source = require('../lib/source');
 
 module.exports = {};
 module.exports.createTmpProject = createTmpProject;
-module.exports.cleanup = cleanup;
 
 var tests = {};
 
@@ -16,7 +15,7 @@ var tests = {};
 function createTmpProject(testname, id, callback) {
     if (typeof testname !== 'string') throw new Error('testname must be a string');
 
-    testname = 'tm2-' + testname;
+    testname = testname;
 
     var key = testname + '-' + id;
     var lib = id.indexOf('tmsource') === 0 ? libs.source : libs.style;
@@ -52,15 +51,5 @@ function createTmpProject(testname, id, callback) {
             });
         });
     });
-}
-
-function cleanup() {
-    for (var key in tests) {
-        var tmpdir = tm.parse(tests[key].id).dirname;
-        ['data.xml','data.yml','project.xml','project.yml','style.mss','.thumb.png'].forEach(function(f) {
-            try { fs.unlinkSync(path.join(tmpdir, f)); } catch(err) {}
-        });
-        try { fs.rmdirSync(tmpdir); } catch(err) {}
-    }
 }
 


### PR DESCRIPTION
Removes cleanup from main testing processes into a posttest script. Uses node/rimraf for windows support (no rm -rf).
