### PR TITLE
Reduce competing export actions

### DIFF
--- a/templates/source.html
+++ b/templates/source.html
@@ -55,8 +55,8 @@
           </div>
           <a href='/upload?id=<%= source.id %>' class='col12 short button round-bottom icon up'>Upload to Mapbox</a>
         </section>
-        <section>
-          <a href='/mbtiles?id=<%= source.id %>' class='col12 short button icon package'>MBTiles Export</a>
+        <section class='small center'>
+          <a href='/mbtiles?id=<%= source.id %>' class='icon package'>or export to MBTiles</a>
         </section>
       </fieldset>
       <fieldset class='pad1x'>

--- a/templates/style.html
+++ b/templates/style.html
@@ -161,11 +161,8 @@
           </div>
           <a href='#settings' class='js-upload col12 short button round-bottom icon up'>Upload to Mapbox</a>
         </section>
-        <section class='space-bottom1'>
-          <a href='#export' id='export-style' class='col12 short button picture icon'>Export image</a>
-        </section>
-        <section>
-          <a href='/style.tm2z?id=<%= style.id %>' class='col12 short button icon package'>Download package</a>
+        <section class='small center'>
+          <a href='/style.tm2z?id=<%= style.id %>' class='icon package'>or download package</a>
         </section>
       </fieldset>
       <fieldset class='pad1x'>


### PR DESCRIPTION
![share-source](https://cloud.githubusercontent.com/assets/83384/4040132/433dfb7a-2cdd-11e4-8ff5-e456d409d3e3.png)
![share-style](https://cloud.githubusercontent.com/assets/83384/4040133/433fd508-2cdd-11e4-8b26-11f83206ec4b.png)

Removes redundant export image button and puts emphasis on upload action over export. https://github.com/mapbox/mapbox-studio/issues/670

@samanpwbb @nickidlugash 
