### PR TITLE
fix keybindings

### DIFF
--- a/app/source.js
+++ b/app/source.js
@@ -114,8 +114,11 @@ window.Source = function(templates, cwd, tm, source, revlayers, examples) {
     Editor.prototype.keys = function(ev) {
         // Escape. Collapses windows, dialogs, modals, etc.
         if (ev.which === 27) {
-            if (Modal.active) Modal.close();
-            window.location.href = '#';
+            if (Modal.active) {
+              Modal.close();
+            } else {
+              window.location.href = '#';
+            }
         }
         if ((!ev.ctrlKey && !ev.metaKey) || ev.shiftKey) return;
         var which = ev.which;
@@ -127,23 +130,16 @@ window.Source = function(templates, cwd, tm, source, revlayers, examples) {
                 ev.preventDefault();
                 this.togglePane('full');
                 break;
-            case (which === 72): // h for help
-                ev.preventDefault();
-                this.togglePane('docs');
-                break;
             case (which === 220): // \ for settings
                 ev.preventDefault();
                 this.togglePane('settings');
-                break;
-            case (which === 66): // b for bookmarks
-                ev.preventDefault();
-                this.togglePane('bookmark');
                 break;
             default:
                 return true;
         }
         return false;
     };
+
     Editor.prototype.saveModal = function() {
         Modal.show('browsersave', {
             type: 'source',
@@ -603,10 +599,10 @@ window.Source = function(templates, cwd, tm, source, revlayers, examples) {
     Editor.prototype.zoomToLayer = function(ev) {
         var id = $(ev.currentTarget).attr('id').split('zoom-').pop();
         var filepath = layers[id].get().Datasource.file;
-        
+
         // Set map in loading state
         $('#full').addClass('loading');
-        
+
         $.ajax({
             url: '/metadata?file=' + filepath,
             success: function(metadata) {

--- a/app/style.js
+++ b/app/style.js
@@ -266,23 +266,23 @@ Editor.prototype.changed = function() {
 Editor.prototype.keys = function(ev) {
   // Escape. Collapses windows, dialogs, modals, etc.
   if (ev.which === 27) {
-    if (Modal.active) Modal.close();
-    window.location.href = '#';
+    if (Modal.active) {
+      Modal.close();
+    } else {
+      window.location.href = '#';
+    }
   }
   if ((!ev.ctrlKey && !ev.metaKey) || ev.shiftKey) return;
 
   var which = ev.which;
   switch (true) {
-  case (which === 83): // s
-    this.save();
-    break;
-  case (which === 72): // h for help
-    ev.preventDefault();
-    this.togglePane('docs');
-    break;
   case (which === 190): // . for fullscreen
     ev.preventDefault();
     this.togglePane('full');
+    break;
+  case (which === 191): // / for help
+    ev.preventDefault();
+    this.togglePane('docs');
     break;
   case (which === 73): // i for layers/data
     ev.preventDefault();
@@ -292,27 +292,31 @@ Editor.prototype.keys = function(ev) {
     ev.preventDefault();
     this.togglePane('settings');
     break;
-  case (which === 66): // b for bookmarks
-    ev.preventDefault();
-    this.togglePane('bookmark');
-    break;
-    case (which === 69): // e for export-pane
-    ev.preventDefault();
-    this.togglePane('export');
-    break;
-  case ((which > 48 && which < 58) && ev.altKey): // 1-9 + alt
-    var tab = $('#tabs a.tab')[(which-48)-1];
-    if (tab) $(tab).click();
-    break;
   case (which === 80): // p for places
     ev.preventDefault();
     this.togglePane('places');
+    break;
+  case (which === 83 && ev.altKey): // alt + s for export
+    ev.preventDefault();
+    this.togglePane('export');
+    break;
+  case (which === 83): // s for save
+    this.save();
+    break;
+  case (which === 66): // b for bookmarks
+    ev.preventDefault();
+    window.editor.addBookmark(ev);
+    break;
+  case ((which > 48 && which < 58)): // 1-9
+    var tab = $('#tabs a.tab')[(which-48)-1];
+    if (tab) $(tab).click();
     break;
   default:
     return true;
   }
   return false;
 };
+
 Editor.prototype.saveModal = function() {
   Modal.show('browsersave', {type:'style', cwd:cwd});
   new views.Browser({

--- a/app/style.js
+++ b/app/style.js
@@ -307,7 +307,7 @@ Editor.prototype.keys = function(ev) {
     ev.preventDefault();
     window.editor.addBookmark(ev);
     break;
-  case ((which > 48 && which < 58)): // 1-9
+  case ((which > 48 && which < 58) && ev.altKey): // 1-9
     var tab = $('#tabs a.tab')[(which-48)-1];
     if (tab) $(tab).click();
     break;

--- a/app/test/app.test.source.js
+++ b/app/test/app.test.source.js
@@ -298,21 +298,9 @@ tape('keybindings', function(t) {
 
     e = $.Event('keydown');
     e.ctrlKey = true;
-    e.which = 72; // h
-    $('body').trigger(e);
-    t.equal(window.location.hash, '#docs', 'ctrl+h => #help');
-
-    e = $.Event('keydown');
-    e.ctrlKey = true;
     e.which = 220; // backslash
     $('body').trigger(e);
     t.equal(window.location.hash, '#settings', 'ctrl+\\ => #settings');
-
-    e = $.Event('keydown');
-    e.ctrlKey = true;
-    e.which = 66; // backslash
-    $('body').trigger(e);
-    t.equal(window.location.hash, '#bookmark', 'ctrl+b => #bookmark');
 
     t.end();
 });

--- a/app/test/app.test.style.js
+++ b/app/test/app.test.style.js
@@ -356,9 +356,9 @@ tape('keybindings', function(t) {
 
     e = $.Event('keydown');
     e.ctrlKey = true;
-    e.which = 72; // h
+    e.which = 191; // /
     $('body').trigger(e);
-    t.equal(window.location.hash, '#docs', 'ctrl+h => #help');
+    t.equal(window.location.hash, '#docs', 'ctrl+/ => #help');
 
     e = $.Event('keydown');
     e.ctrlKey = true;
@@ -374,21 +374,16 @@ tape('keybindings', function(t) {
 
     e = $.Event('keydown');
     e.ctrlKey = true;
-    e.which = 66; // b
-    $('body').trigger(e);
-    t.equal(window.location.hash, '#bookmark', 'ctrl+b => #bookmark');
-
-    e = $.Event('keydown');
-    e.ctrlKey = true;
-    e.which = 69; // e
-    $('body').trigger(e);
-    t.equal(window.location.hash, '#export', 'ctrl+e => #export');
-
-    e = $.Event('keydown');
-    e.ctrlKey = true;
     e.which = 80; // b
     $('body').trigger(e);
     t.equal(window.location.hash, '#places', 'ctrl+p => #places');
+
+    e = $.Event('keydown');
+    e.ctrlKey = true;
+    e.altKey = true; // alt
+    e.which = 83; // s
+    $('body').trigger(e);
+    t.equal(window.location.hash, '#export', 'ctrl+alt+s => #export');
 
     var e;
     e = $.Event('keydown');
@@ -399,6 +394,15 @@ tape('keybindings', function(t) {
     onajax(function() {
         t.ok(!$('#full').hasClass('loading'), 'ctrl+s => #full');
         t.equal($('body').hasClass('changed'), false, 'ctrl+s => saved style');
+    });
+
+    var e;
+    e = $.Event('keydown');
+    e.ctrlKey = true;
+    e.which = 66; // b
+    $('body').trigger(e);
+    t.ok($('.js-add-bookmark').hasClass('spinner'), 'ctrl+b => #add-bookmark.spinner');
+    onajax(function() {
         t.end();
     });
 });


### PR DESCRIPTION
- `esc` only closes modal if modal is visible (fix #548)
- `ctrl+b` now saves a bookmark of current map view
- `ctrl+/` is now help (fix #715)
- `ctrl+alt+s` is now export (fix #662)
- ~~`ctrl+[1-9]` is now tab switch. The old `ctrl+alt+[1-9]` was super awkward, and when running studio as an app, rather than in browser, doesn't conflict with anything.~~
