### PR TITLE
Cleanup styles + reformat default display

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -14,6 +14,8 @@
   width: auto;
 }
 
+.code { word-break: break-all;}
+
 /* Hover/acive fills */
 .fill-lighten0-onhover:hover { background:rgba(255,255,255,0.10); }
 .fill-blue-onactive.active { background:#3887be; }

--- a/app/style.css
+++ b/app/style.css
@@ -195,7 +195,7 @@
   background: rgba(0,0,0,.05);
 }
 
-.reference-option { margin-bottom: 3px;}
+.reference-entry { margin-bottom: 3px;}
 
 #reference section.active a,
 #reference .details { display: none;}

--- a/app/style.css
+++ b/app/style.css
@@ -191,27 +191,11 @@
   border-top: 1px solid rgba(0,0,0,0.25);
 }
 
-#reference .code.value,
-#reference .code.options {
-  color:rgba(0,0,0,.75);
-  padding:2px 5px;
-  border-radius: 3px;
-  background: rgba(241, 240, 117, 1);
-}
-
-#reference .code.value:before {
-  content:'default: ';
-  color: rgba(0,0,0,.5);
-  }
-
-#reference .code.options:before {
-  content:'options: ';
-  color: rgba(0,0,0,.5);
-}
-
 #reference section.carto-ref:not(.active):hover {
   background: rgba(0,0,0,.05);
 }
+
+.reference-option { margin-bottom: 2px;}
 
 #reference section.active a,
 #reference .details { display: none;}

--- a/app/style.css
+++ b/app/style.css
@@ -195,7 +195,7 @@
   background: rgba(0,0,0,.05);
 }
 
-.reference-option { margin-bottom: 2px;}
+.reference-option { margin-bottom: 3px;}
 
 #reference section.active a,
 #reference .details { display: none;}

--- a/templates/stylereference.html
+++ b/templates/stylereference.html
@@ -71,12 +71,24 @@ var sections = {
     <span class='quiet micro pin-topright pad0 code type'><%=_(p.type).isArray() ? 'option block' : p.type%></span>
     </a>
     <div class='pad1 details'>
-    <% if (p['default-value'] && p['default-value']!=='none') { %>
-    <span class='space-bottom1 code quiet inline value'><%=p['default-value']%></span><br/>
-    <% } %>
-    <% if (_(p.type).isArray()) { %><span class='space-bottom1 inline code options'><%= p.type.join(' ') %></span><br/><% } %>
-    <% if (p.doc) { %><div class='space-bottom1 quiet description break-word small'><%=p.doc%></div><% } %>
+    <div class='quiet'>
+      <div class='space-bottom0'>Default:</div>
+      <!-- 'false' and 'none' are valid default values, so show those. Only hide if default is empty.' -->
+      <% if (!(p['default-value'] === '')) { %>
+      <span class='space-bottom1 code pad0x round fill-darken1 inline value'><%= p['css'] %>: <%=p['default-value']%>;</span>
+      <% } else { %>
+      <span class='space-bottom1 code pad0x round inline fill-darken1'>no default value</span>
+      <% } %>
+      <% if (_(p.type).isArray()) { %>
+      <div class='space-bottom0'>Options:</div>
+      <div class='space-bottom1'>
+        <% _(p.type).each(function(option, i) { %>
+          <span class='pad0x reference-option code inline fill-darken1 quiet round'><%= option %></span>
+        <% }); %>
+      </div>
+      <% } %>
     </div>
+    <% if (p.doc) { %><div class='space-bottom1 quiet description break-word small'><%=p.doc%></div><% } %>
   </section>
   <% }); %>
   <% }); %>

--- a/templates/stylereference.html
+++ b/templates/stylereference.html
@@ -87,7 +87,7 @@ var sections = {
       <div class='space-bottom0'>Options:</div>
       <div class='micro space-bottom1'>
         <% _(p.type).each(function(option, i) { %>
-          <span class='pad0x reference-option code inline fill-darken1 quiet round'><%= option %></span>
+          <span class='pad0x reference-entry code inline fill-darken1 quiet round'><%= option %></span>
         <% }); %>
       </div>
       <% } %>
@@ -103,11 +103,11 @@ var sections = {
       <div class='space-bottom1'>
         <div class='space-bottom0'>Examples:</div>
         <% if (p.serialization==='content') { %>
-          <div><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: "[name]";</span></div>
-          <div><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: "'zoo'";</span></div>
+          <div class='reference-entry'><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: "[name]";</span></div>
+          <div class='reference-entry'><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: "'zoo'";</span></div>
         <% } else { %>
-          <div><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: [scalerank];</span></div>
-          <div><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: 5;</span></div>
+          <div class='reference-entry'><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: [scalerank];</span></div>
+          <div class='reference-entry'><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: 5;</span></div>
         <% } %>
       </div>
       <% } %>
@@ -116,14 +116,15 @@ var sections = {
           <div class='space-bottom0'>Example:</div>
           <span class='space-bottom1 micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: 2,2;</span>
       <% } %>
+
       <% if (p.type==='color') { %>
           <div class='space-bottom1'>
           <div class='space-bottom0'>Examples:</div>
-            <div><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: #ffff00;</span></div>
-            <div><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: rgb(255, 255, 0);</span></div>
-            <div><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: rgba(255, 255, 0, 1);</span></div>
-            <div><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: hsl(100, 50%, 50%);</span></div>
-            <div><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: yellow;</span></div>
+            <div class='reference-entry'><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: #ffff00;</span></div>
+            <div class='reference-entry'><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: rgb(255, 255, 0);</span></div>
+            <div class='reference-entry'><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: rgba(255, 255, 0, 1);</span></div>
+            <div class='reference-entry'><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: hsl(100, 50%, 50%);</span></div>
+            <div class='reference-entry'><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: yellow;</span></div>
           </div>
       <% } %>
 
@@ -131,11 +132,10 @@ var sections = {
         <div class='space-bottom1'>
           <div class='space-bottom0'>Examples:</div>
          <% _(p.functions).each(function(option, i) { %>
-            <div><span class='micro inline pad0x code fill-darken1 quiet round'><%= p['css'] %>: <%= option[0] %>(<% for (var i=0;i<option[1];i++) {%>2<%= (option[1]===(i+1)) ? '' : ',' %><% } %>);</span></div>
+          <div class='reference-entry'><span class='micro inline pad0x code fill-darken1 quiet round'><%= p['css'] %>:<%= option[0] %>(<% if (option[0] === 'colorize-alpha') { %>blue, yellow, red<% } else if (option[0] === 'color-to-alpha') { %>blue<% } else { %><% for (var i=0;i<option[1];i++) {%>2<%= (option[1]===(i+1)) ? '' : ',' %><% } %><% } %>);</span></div>
           <% }); %>
         </div>
       <% }; %>
-
     </div>
     <% if (p.doc) { %><div class='space-bottom1 quiet description break-word small'><%=p.doc%></div><% } %>
   </section>

--- a/templates/stylereference.html
+++ b/templates/stylereference.html
@@ -68,25 +68,74 @@ var sections = {
   <section id='reference-<%= p.css.replace(/[^\w+]/g,'_') %>' class='contain carto-ref'>
     <a href='#reference-<%= p.css.replace(/[^\w+]/g,'_') %>' class='js-tab pin-left pin-right js-tab'></a>
     <div class='small pad1x pad0y keyline-bottom'><%= p.css %></div>
-    <span class='quiet micro pin-topright pad0 code type'><%=_(p.type).isArray() ? 'option block' : p.type%></span>
+    <span class='quiet micro pin-topright pad0 code type'><%=_(p.type).isArray() ? 'keyword' : p.type%></span>
     </a>
     <div class='pad1 details'>
     <div class='quiet'>
       <div class='space-bottom0'>Default:</div>
+
       <!-- 'false' and 'none' are valid default values, so show those. Only hide if default is empty.' -->
+      <div class='space-bottom1'>
       <% if (!(p['default-value'] === '')) { %>
-      <span class='space-bottom1 code pad0x round fill-darken1 inline value'><%= p['css'] %>: <%=p['default-value']%>;</span>
+        <span class='micro code pad0x round fill-darken1 inline value'><%= p['css'] %>: <%=p['default-value']%>;</span>
       <% } else { %>
-      <span class='space-bottom1 code pad0x round inline fill-darken1'>no default value</span>
+        <span class='micro code pad0x round inline fill-darken1'>no default value</span>
       <% } %>
+      </div>
+
       <% if (_(p.type).isArray()) { %>
       <div class='space-bottom0'>Options:</div>
-      <div class='space-bottom1'>
+      <div class='micro space-bottom1'>
         <% _(p.type).each(function(option, i) { %>
           <span class='pad0x reference-option code inline fill-darken1 quiet round'><%= option %></span>
         <% }); %>
       </div>
       <% } %>
+
+      <% if (p.type==='uri') { %>
+      <div class='space-bottom1'>
+        <div class='space-bottom0'>Example:</div>
+        <span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: url("image.png");</span>
+      </div>
+      <% } %>
+
+      <% if (p.type==='expression') { %>
+      <div class='space-bottom1'>
+        <div class='space-bottom0'>Examples:</div>
+        <% if (p.serialization==='content') { %>
+          <div><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: "[name]";</span></div>
+          <div><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: "'zoo'";</span></div>
+        <% } else { %>
+          <div><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: [scalerank];</span></div>
+          <div><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: 5;</span></div>
+        <% } %>
+      </div>
+      <% } %>
+
+      <% if (p.type==='numbers') { %>
+          <div class='space-bottom0'>Example:</div>
+          <span class='space-bottom1 micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: 2,2;</span>
+      <% } %>
+      <% if (p.type==='color') { %>
+          <div class='space-bottom1'>
+          <div class='space-bottom0'>Examples:</div>
+            <div><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: #ffff00;</span></div>
+            <div><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: rgb(255, 255, 0);</span></div>
+            <div><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: rgba(255, 255, 0, 1);</span></div>
+            <div><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: hsl(100, 50%, 50%);</span></div>
+            <div><span class='micro pad0x code inline fill-darken1 quiet round'><%= p['css'] %>: yellow;</span></div>
+          </div>
+      <% } %>
+
+      <% if (p.functions) { %>
+        <div class='space-bottom1'>
+          <div class='space-bottom0'>Examples:</div>
+         <% _(p.functions).each(function(option, i) { %>
+            <div><span class='micro inline pad0x code fill-darken1 quiet round'><%= p['css'] %>: <%= option[0] %>(<% for (var i=0;i<option[1];i++) {%>2<%= (option[1]===(i+1)) ? '' : ',' %><% } %>);</span></div>
+          <% }); %>
+        </div>
+      <% }; %>
+
     </div>
     <% if (p.doc) { %><div class='space-bottom1 quiet description break-word small'><%=p.doc%></div><% } %>
   </section>


### PR DESCRIPTION
Reworked a lot of reference entries with better default displays + examples:

If type=uri, show examples:
![screen shot 2014-09-04 at 12 55 26 pm](https://cloud.githubusercontent.com/assets/108094/4153144/5842d3e0-3455-11e4-87ee-654e8b76b62a.png)

if options is array, list all options separately. Also, rename type from 'block' to 'keyword' (not sure if this is technically correct, but it makes more sense to me):
![screen shot 2014-09-04 at 12 55 21 pm](https://cloud.githubusercontent.com/assets/108094/4153160/80495f1c-3455-11e4-96f1-b24f60561511.png)

if type=function, show examples of all available functions:
![screen shot 2014-09-04 at 12 55 13 pm](https://cloud.githubusercontent.com/assets/108094/4153175/a07d636e-3455-11e4-9763-e021840bd7e9.png)

If type=expression and serialization=content, show examples for both printing arbitrary text and using existing fields:
![screen shot 2014-09-04 at 1 01 21 pm](https://cloud.githubusercontent.com/assets/108094/4153197/d7556594-3455-11e4-95b3-bec54bafc40b.png)

All other type=expression parameters get both an expression and a number example:
![screen shot 2014-09-04 at 12 54 56 pm](https://cloud.githubusercontent.com/assets/108094/4153200/e3ef1a66-3455-11e4-90be-a933ef050543.png)

If type=color, show examples: 
![screen shot 2014-09-04 at 12 54 49 pm](https://cloud.githubusercontent.com/assets/108094/4153209/f4debb88-3455-11e4-89e4-d9143cfa3b21.png)

Co-ordinating with updates to Mapnik reference: https://github.com/mapnik/mapnik-reference/issues/67

Todo:
- [x] Add examples for most parameters.
- [ ] Fix tests
