### PR TITLE
added komika fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "tilelive-bridge": "0.6.0",
     "tilelive-vector": "2.1.0",
     "mapbox-studio-pro-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-pro-fonts-1.0.0-9870a90b713f307b9391829602f4d5857e419615.tgz",
-    "mapbox-studio-default-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-default-fonts-0.0.1-d14108c11fc92b6b2894cad73f36924bc1ccfa4c.tgz",
+    "mapbox-studio-default-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-default-fonts-0.0.2-20941da92fd3b9957de949df96f5fce856c3ad01.tgz",
     "mapbox-studio-default-style": "1.0.0",
     "mapbox-studio-default-source": "1.0.0",
     "mapbox-outdoors": "1.0.0",

--- a/test/expected/fontfamilies.json
+++ b/test/expected/fontfamilies.json
@@ -260,6 +260,13 @@
     "Kievit SC Offc Pro Extralight",
     "Kievit SC Offc Pro Extralight Italic"
   ],
+  "Komika Hand": [
+    "Komika Hand Italic"
+  ],
+  "Komika Title": [
+    "Komika Title Regular",
+    "Komika Title Bold"
+  ],
   "Lato": [
     "Lato Regular",
     "Lato Bold",


### PR DESCRIPTION
an update to the default-fonts-package for use in [this map](https://api.tiles.mapbox.com/v4/duncangraham.c7871562/page.html?access_token=pk.eyJ1IjoiZHVuY2FuZ3JhaGFtIiwiYSI6IlJJcWdFczQifQ.9HUpTV1es8IjaGAf_s64VQ#10/37.9745/-84.4643)

added 

Komika Hand Italic
Komika Title Regular
Komika Title Bold
