### PR TITLE
Less Call (font) spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 - Style UI: tags displayed and clickable to filter places UI.
 - Upgrade mapbox-upload to 1.1.1.
 - Upgrade mapbox-studio-default-fonts to 0.0.2 (adds Komika fonts).
+- Style UI: reduce spam of font UI from Call fonts.
 
 ### 0.0.8
 

--- a/lib/tm.js
+++ b/lib/tm.js
@@ -359,7 +359,7 @@ tm.font = function(name, text, callback) {
             return callback(null, buffer);
         }
 
-        var map = new mapnik.Map(500,60);
+        var map = new mapnik.Map(1000,60);
         map.extent = [-180,-10,180,10];
         map.fromString(xml, function(err) {
             if (err) return callback(err);

--- a/lib/tm.js
+++ b/lib/tm.js
@@ -386,6 +386,12 @@ tm.fontfamilies = function() {
     if (tm._fontfamilies) return tm._fontfamilies;
 
     var fonts = require('mapnik').fonts();
+    fonts.sort();
+    // Overrides are custom exceptions -- regexes for known font family
+    // names that cannot otherwise be autodetected.
+    var overrides = {
+        'Call': /^Call (One|Two|Three|Four|Five|Six|Seven|Eight|Nine)/
+    };
     // Keywords are ordered by "display priority" -- e.g. fonts
     // containing earlier words should be favored for being a preview
     // of the family as a whole.
@@ -418,6 +424,16 @@ tm.fontfamilies = function() {
     ];
     var level1 = {};
     for (var i = 0; i < fonts.length; i++) {
+        var overridden = false;
+        for (var family in overrides) {
+            if (overrides[family].test(fonts[i])) {
+                level1[family] = level1[family] || [];
+                level1[family].push(fonts[i]);
+                overridden = true;
+            }
+        }
+        if (overridden) continue;
+
         var parts = fonts[i].split(' ');
         while (parts.length) {
             var word = parts[parts.length-1];
@@ -453,7 +469,10 @@ tm.fontfamilies = function() {
             level1[family] = level2[family];
         }
     }
-    for (var k in level1) level1[k].sort(famsort);
+    for (var k in level1) {
+        if (overrides[k]) continue;
+        level1[k].sort(famsort);
+    }
 
     function famsort(a, b) {
         var ascore = 0;

--- a/test/expected/fontfamilies.json
+++ b/test/expected/fontfamilies.json
@@ -11,89 +11,43 @@
     "Brokenscript Rough OT Bold",
     "Brokenscript Rough OT Cond Bold"
   ],
-  "Call Eight Negative OT": [
-    "Call Eight Negative OT Regular"
-  ],
-  "Call Eight OT": [
+  "Call": [
+    "Call Eight Negative OT Regular",
+    "Call Eight OT Italic",
     "Call Eight OT Regular",
-    "Call Eight OT Italic"
-  ],
-  "Call Five L Negative OT": [
-    "Call Five L Negative OT Regular"
-  ],
-  "Call Five L OT": [
+    "Call Five L Negative OT Regular",
+    "Call Five L OT Italic",
     "Call Five L OT Regular",
-    "Call Five L OT Italic"
-  ],
-  "Call Five S Negative OT": [
-    "Call Five S Negative OT Regular"
-  ],
-  "Call Five S OT": [
+    "Call Five S Negative OT Regular",
+    "Call Five S OT Italic",
     "Call Five S OT Regular",
-    "Call Five S OT Italic"
-  ],
-  "Call Four L Negative OT": [
-    "Call Four L Negative OT Regular"
-  ],
-  "Call Four L OT": [
+    "Call Four L Negative OT Regular",
+    "Call Four L OT Italic",
     "Call Four L OT Regular",
-    "Call Four L OT Italic"
-  ],
-  "Call Four S Negative OT": [
-    "Call Four S Negative OT Regular"
-  ],
-  "Call Four S OT": [
+    "Call Four S Negative OT Regular",
+    "Call Four S OT Italic",
     "Call Four S OT Regular",
-    "Call Four S OT Italic"
-  ],
-  "Call Nine L Negative OT": [
-    "Call Nine L Negative OT Regular"
-  ],
-  "Call Nine L OT": [
+    "Call Nine L Negative OT Regular",
+    "Call Nine L OT Italic",
     "Call Nine L OT Regular",
-    "Call Nine L OT Italic"
-  ],
-  "Call Nine S Negative OT": [
-    "Call Nine S Negative OT Regular"
-  ],
-  "Call Nine S OT": [
+    "Call Nine S Negative OT Regular",
+    "Call Nine S OT Italic",
     "Call Nine S OT Regular",
-    "Call Nine S OT Italic"
-  ],
-  "Call One Negative OT": [
-    "Call One Negative OT Regular"
-  ],
-  "Call One OT": [
+    "Call One Negative OT Regular",
+    "Call One OT Italic",
     "Call One OT Regular",
-    "Call One OT Italic"
-  ],
-  "Call Seven Negative OT": [
-    "Call Seven Negative OT Regular"
-  ],
-  "Call Seven OT": [
+    "Call Seven Negative OT Regular",
+    "Call Seven OT Italic",
     "Call Seven OT Regular",
-    "Call Seven OT Italic"
-  ],
-  "Call Six Negative OT": [
-    "Call Six Negative OT Regular"
-  ],
-  "Call Six OT": [
+    "Call Six Negative OT Regular",
+    "Call Six OT Italic",
     "Call Six OT Regular",
-    "Call Six OT Italic"
-  ],
-  "Call Three Negative OT": [
-    "Call Three Negative OT Regular"
-  ],
-  "Call Three OT": [
+    "Call Three Negative OT Regular",
+    "Call Three OT Italic",
     "Call Three OT Regular",
-    "Call Three OT Italic"
-  ],
-  "Call Two Negative OT": [
-    "Call Two Negative OT Regular"
-  ],
-  "Call Two OT": [
-    "Call Two OT Regular",
-    "Call Two OT Italic"
+    "Call Two Negative OT Regular",
+    "Call Two OT Italic",
+    "Call Two OT Regular"
   ],
   "Clan Offc Pro": [
     "Clan Offc Pro Medium",


### PR DESCRIPTION
Adds regex-based exception handling in font family grouper to keep `Call {num}` fonts from spamming the font UI.

cc @nickidlugash @samanpwbb 
