### PR TITLE
Show tm2

### DIFF
--- a/app/lib.js
+++ b/app/lib.js
@@ -143,7 +143,7 @@ views.Browser.prototype.initialize = function(options, initCallback) {
   this.callback = options.callback || function() {};
   this.filter = options.filter || function(f) { return true; };
   this.isFile = options.isFile || function() {};
-  this.isProject = options.isProject || function() {};
+  this.isProject = options.isProject || function(f) { return true; };
   this.cwd = this.$('input[name=cwd]').val();
   return this.render();
 };
@@ -167,8 +167,11 @@ views.Browser.prototype.render = function() {
           var fileExt = f.basename.split('.').pop();
           if (fileExt === 'tm2') type = 'paint';
           if (fileExt === 'tm2source') type = 'polygon';
+          // if browsing for a project, emphasize .tm2 & .tmsource files
           var targetFile = view.isFile(f.basename) ? 'quiet' : '';
-          return "<a class='icon " + targetFile + " " + type + " small truncate round block fill-lighten0-onhover fill-blue-onactive' href='#" + f.path + "'>" + f.basename + "</a>";
+          // if saving a file, emphasize directories
+          var targetDir = view.isProject(f.basename) ? '' : 'quiet';
+          return "<a class='icon " + targetFile + " " + targetDir + " " + type + " small truncate round block fill-lighten0-onhover fill-blue-onactive' href='#" + f.path + "'>" + f.basename + "</a>";
         })
         .value()
         .join('\n'));

--- a/app/lib.js
+++ b/app/lib.js
@@ -143,7 +143,7 @@ views.Browser.prototype.initialize = function(options, initCallback) {
   this.callback = options.callback || function() {};
   this.filter = options.filter || function(f) { return true; };
   this.isFile = options.isFile || function() {};
-  this.isProject = options.isProject || function(f) { return true; };
+  this.isProject = options.isProject || function() {};
   this.cwd = this.$('input[name=cwd]').val();
   return this.render();
 };

--- a/app/lib.js
+++ b/app/lib.js
@@ -143,6 +143,7 @@ views.Browser.prototype.initialize = function(options, initCallback) {
   this.callback = options.callback || function() {};
   this.filter = options.filter || function(f) { return true; };
   this.isFile = options.isFile || function() {};
+  this.isProject = options.isProject || function() {};
   this.cwd = this.$('input[name=cwd]').val();
   return this.render();
 };
@@ -197,6 +198,8 @@ views.Browser.prototype.browse = function(ev) {
   var target = $(ev.currentTarget);
   if (target.is('.document') || this.isFile(target.attr('href').split('#').pop())) {
     this.$('input[name=basename]').val(target.text());
+  } else if (target.is('.document') || this.isProject(target.attr('href').split('#').pop())) {
+    // do nothing
   } else if (target.is('.folder.active') || target.is('.prev')) {
     this.cwd = target.attr('href').split('#').pop();
     this.render();

--- a/app/source.js
+++ b/app/source.js
@@ -147,8 +147,8 @@ window.Source = function(templates, cwd, tm, source, revlayers, examples) {
         new views.Browser({
             el: $('.modal-content #saveas'),
             filter: function(file) { return file.type === 'dir' || (/\.tm2source$/.test(file.basename) || /\.tm2$/.test(file.basename)) },
-            isFile: function(file) {
-                return !(/\.tm2source$/.test(file) || /\.tm2$/.test(file));
+            isProject: function(file) {
+              return (/\.tm2source$/.test(file) || /\.tm2$/.test(file));
             },
             callback: function(err, filepath) {
                 if (err) return false; // @TODO

--- a/app/source.js
+++ b/app/source.js
@@ -144,10 +144,18 @@ window.Source = function(templates, cwd, tm, source, revlayers, examples) {
             type: 'source',
             cwd: cwd
         });
+        var pattern = /[\w\d\s\.-]+\.tm2|[\w\d\s\.-]+\.tmsource/;
         new views.Browser({
             el: $('.modal-content #saveas'),
             filter: function(file) {
                 return file.type === 'dir';
+            },
+            isFile: function(file) {
+                if (pattern) {
+                    return pattern.test(file);
+                } else {
+                    return file.type === 'dir';
+                }
             },
             callback: function(err, filepath) {
                 if (err) return false; // @TODO

--- a/app/source.js
+++ b/app/source.js
@@ -144,18 +144,11 @@ window.Source = function(templates, cwd, tm, source, revlayers, examples) {
             type: 'source',
             cwd: cwd
         });
-        var pattern = /[\w\d\s\.-]+\.tm2|[\w\d\s\.-]+\.tmsource/;
         new views.Browser({
             el: $('.modal-content #saveas'),
-            filter: function(file) {
-                return file.type === 'dir';
-            },
+            filter: function(file) { return file.type === 'dir' || (/\.tm2source$/.test(file.basename) || /\.tm2$/.test(file.basename)) },
             isFile: function(file) {
-                if (pattern) {
-                    return pattern.test(file);
-                } else {
-                    return file.type === 'dir';
-                }
+                return !(/\.tm2source$/.test(file) || /\.tm2$/.test(file));
             },
             callback: function(err, filepath) {
                 if (err) return false; // @TODO

--- a/app/source.js
+++ b/app/source.js
@@ -147,7 +147,7 @@ window.Source = function(templates, cwd, tm, source, revlayers, examples) {
         new views.Browser({
             el: $('.modal-content #saveas'),
             filter: function(file) {
-                return file.type === 'dir' && !(/\.tm2$/).test(file.basename);
+                return file.type === 'dir';
             },
             callback: function(err, filepath) {
                 if (err) return false; // @TODO

--- a/app/style.js
+++ b/app/style.js
@@ -333,9 +333,17 @@ Editor.prototype.keys = function(ev) {
 
 Editor.prototype.saveModal = function() {
   Modal.show('browsersave', {type:'style', cwd:cwd});
+  var pattern = /[\w\d\s\.-]+\.tm2|[\w\d\s\.-]+\.tmsource/;
   new views.Browser({
     el: $('.modal-content #saveas'),
     filter: function(file) { return file.type === 'dir'},
+    isFile: function(file) {
+      if (pattern) {
+          return pattern.test(file);
+      } else {
+          return file.type === 'dir';
+      }
+    },
     callback: function(err, filepath) {
       if (err) return false; // @TODO
       filepath = filepath.replace(/\.tm2/,'') + '.tm2';

--- a/app/style.js
+++ b/app/style.js
@@ -333,16 +333,11 @@ Editor.prototype.keys = function(ev) {
 
 Editor.prototype.saveModal = function() {
   Modal.show('browsersave', {type:'style', cwd:cwd});
-  var pattern = /[\w\d\s\.-]+\.tm2|[\w\d\s\.-]+\.tmsource/;
   new views.Browser({
     el: $('.modal-content #saveas'),
-    filter: function(file) { return file.type === 'dir'},
-    isFile: function(file) {
-      if (pattern) {
-          return pattern.test(file);
-      } else {
-          return file.type === 'dir';
-      }
+    filter: function(file) { return file.type === 'dir' || (/\.tm2source$/.test(file.basename) || /\.tm2$/.test(file.basename)) },
+    isProject: function(file) {
+      return (/\.tm2source$/.test(file) || /\.tm2$/.test(file));
     },
     callback: function(err, filepath) {
       if (err) return false; // @TODO

--- a/app/style.js
+++ b/app/style.js
@@ -335,7 +335,7 @@ Editor.prototype.saveModal = function() {
   Modal.show('browsersave', {type:'style', cwd:cwd});
   new views.Browser({
     el: $('.modal-content #saveas'),
-    filter: function(file) { return file.type === 'dir' && !(/\.tm2$/).test(file.basename); },
+    filter: function(file) { return file.type === 'dir'},
     callback: function(err, filepath) {
       if (err) return false; // @TODO
       filepath = filepath.replace(/\.tm2/,'') + '.tm2';


### PR DESCRIPTION
re: #794 -- Now you can see `.tm2` and `.tmsource` files in the file browser but cannot navigate into them.

Potentially in conflict with @samanpwbb's improvements re: https://github.com/mapbox/mapbox-studio/issues/755, 'openable' files are now highlighted (e.g. when saving, directories are emphasized; when browsing for a project, the `.tm2` and `.tmsource` files are emphasized):

**Saving:**
![screen shot 2014-09-09 at 6 33 22 pm](https://cloud.githubusercontent.com/assets/3952537/4211567/5811a4a2-388b-11e4-83ea-81ad78043400.png)

**Browsing:**
![screen shot 2014-09-09 at 6 38 08 pm](https://cloud.githubusercontent.com/assets/3952537/4211569/5c232a2a-388b-11e4-9470-7f26bdad5b56.png)
