### PR TITLE
simplify usage of dark class

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -373,8 +373,6 @@ body.local .on-local { display:block; }
 .dark #map { background-color: #222;}
 #full:target #map { left:0% !important;}
 
-#map.map-clickable { cursor: pointer;}
-
 .map-controls,
 .map-controls .fill-dark,
 .search-results { background: #525252;}

--- a/app/style.js
+++ b/app/style.js
@@ -15,13 +15,13 @@ var placeentry = '<div class="col4 contain places-entry-container animate">' +
                         '<small class="place-label pad1 pin-bottom strong"><%= place_name %></small>' +
                       '</a>' +
                       '<% if (tags.indexOf("userbookmark")) { %>' +
-                      '<div class="pin-top z10 dark pad1">' +
+                      '<div class="pin-top z10 pad1">' +
                         '<% _.each(tags, function(currenttag) { %>' +
                         '<a href="#" class="quiet truncate js-placetag entry-placetag pad0x micro strong fill-dark round inline" tag="<%= currenttag %>"><%= currenttag %></a>' +
                         '<% }); %>' +
                       '</div>' +
                       '<% } else { %>' +
-                      '<a href="#" index="<%= index %>" class="js-del-bookmark icon quiet trash pin-topright pad1"></a>' +
+                      '<a href="#" index="<%= index %>" class="js-del-bookmark fill-darken1 icon quiet trash pin-topright pad1"></a>' +
                       '<% } %>' +
                     '</div>'
                   '</div>';
@@ -196,7 +196,7 @@ Editor.prototype.renderPlaces = function(filter) {
   });
 
   if (filtered.length === 0) {
-    $('#placeslist').html('<div class="dark empty-places col12 pad4 center"><h1>No Places.</h1></div>');
+    $('#placeslist').html('<div class="empty-places col12 pad4 center"><h1>No Places.</h1></div>');
     return false;
   }
 

--- a/templates/source.html
+++ b/templates/source.html
@@ -109,17 +109,17 @@
 
 </div>
 
-<div id='full' class='clip animate pin-left'>
-  <div id='map' class='animate fill-canvas dark' style='background-color:<%=source.background%>;'></div>
+<div id='full' class='clip dark fill-dark animate pin-left'>
+  <div id='map' class='animate fill-canvas' style='background-color:<%=source.background%>;'></div>
   <div id='map-overlay'></div>
   <div id='map-errors'></div>
 
-  <form id='search' class='z10 contain dark round animate search-results'>
+  <form id='search' class='z10 contain round animate search-results'>
     <input id='dosearch' type='text' class='col12 clean small round' value='' placeholder='Search' autocomplete='off' />
     <ul id='search-results' class='clip scroll-styled round-bottom'></ul>
   </form>
-  <div class='map-controls pin-top dark fill-dark row1'>
-    <div class='pin-left fill-dark z1 pad0 row1 truncate'>
+  <div class='map-controls pin-top row1'>
+    <div class='pin-left z1 pad0 row1 truncate'>
       <a href='#search' class='search-n button short icon search quiet'></a>
       <a href='#' class='search-y button short icon active icon search quiet'></a>
 

--- a/templates/style.html
+++ b/templates/style.html
@@ -53,10 +53,10 @@
   <div id='modal-content' class='limiter contain modal-content animate'></div>
 </div>
 
-<div id='full' class='z1 clip animate pin-left'>
+<div id='full' class='z1 clip animate pin-left dark fill-dark'>
   <div id='map' class='animate fill-canvas' style='background-color:<%=style.background%>;'></div>
   <div id='places' class='z10 animate pin-left fill-dark col12'>
-    <div class='pin-top z10 pad1 dark'>
+    <div class='pin-top z10 pad1'>
       <a href='#' class='icon x pin-right pad1 quiet'></a>
       <a href='#' class='js-show-search show-search-button icon search pin-topright button short quiet'></a>
       <form id='places-search' class='animate js-places-container places-search-container z10 col12 fill-dark offcanvas-top clearfix pin-top'>
@@ -64,7 +64,7 @@
         <a href='#' class='pin-right button quiet icon search short js-places-search'>Search</a>
         <a href='#' class='icon js-hide-search x pin-right keyline-left pad1 quiet'></a>
       </form>
-      <div class='dark pad0x pin-topleft places-toggle'>
+      <div class='pad0x pin-topleft places-toggle'>
         <div class='rounded-toggle col12 clearfix strong center micro truncate js-places-toggle'>
           <input id='road' type='radio' name='rtoggle' value='road' checked='checked' class='js-places'>
           <label class='col2' for='road'>Roads</label>
@@ -86,12 +86,12 @@
   <div id='map-overlay' class='overlay'></div>
   <div id='map-errors'></div>
 
-  <form id='search' class='z10 contain dark round animate search-results'>
+  <form id='search' class='z10 contain round animate search-results'>
     <input id='dosearch' type='text' class='col12 clean small round' value='' placeholder='Search' autocomplete='off' />
     <ul id='search-results' class='clip scroll-styled round-bottom'></ul>
   </form>
-  <div class='map-controls pin-top dark fill-dark row1'>
-    <div class='pin-left fill-dark z1 pad0 row1 truncate'>
+  <div class='map-controls pin-top row1'>
+    <div class='pin-left z1 pad0 row1 truncate'>
       <div class='pill inline align-top'>
         <a href='#search' class='search-n search-button button short icon search quiet'></a><!--
      --><a href='#' class='search-y button search-button short icon active icon search quiet'></a><!--
@@ -113,7 +113,7 @@
         --><a href='#export' title='Center crop area based on view' id='recenter' class='quiet icon crosshair button js-recenter short'>Center</a>
       </div>
     </div>
-    <div class='pin-top text-right fill-dark z0 pad0 row1'>
+    <div class='pin-top text-right z0 pad0 row1'>
       <span id='map-center' class='quiet js-mapCenter inline micro strong pad0y align-top'></span>
       <div id='zoomedto' class='align-top text-right inline contain zoom<%=style.center[2]%>'></div>
     </div>


### PR DESCRIPTION
Simplifies usage of 'dark' to apply only to map parent element. Fixes a problem where map errors were shown as dark text against dark background.
