### PR TITLE
Invalidate local sources on refresh

### DIFF
--- a/lib/source.js
+++ b/lib/source.js
@@ -126,7 +126,7 @@ source.refresh = function(rawdata, callback) {
                 return callback(err);
             }
             var ctj = CachingTileJSON(TileJSON, tm.config().cache);
-            return cache[id] ? done(null, cache[id]) : new ctj({data:info}, done);
+            return cache[id] ? loaded(null, cache[id]) : new ctj({data:info}, loaded);
         });
     // local sources
     } else {
@@ -158,15 +158,24 @@ source.refresh = function(rawdata, callback) {
             opts.xml = xml;
             opts.base = uri.dirname;
             var cb = CachingBridge(Bridge, tm.config().cache);
-            return cache[id] ? cache[id].update(opts, done) : new cb(opts, done);
+            return cache[id] ? cache[id].update(opts, loaded) : new cb(opts, loaded);
         });
     }
 
-    function done(err, p) {
+    function loaded(err, p) {
         if (err) return callback(err);
         cache[id] = cache[id] || p;
         cache[id].data = data;
         cache[id].xml = xml;
+        if (remote) {
+            done();
+        } else {
+            source.invalidate(id, done);
+        }
+    }
+
+    function done(err) {
+        if (err) return callback(err);
         xray({
             source: cache[id],
             minzoom: data.minzoom,
@@ -187,20 +196,13 @@ source.save = function(rawdata, callback) {
     var id = rawdata.id;
     var uri = tm.parse(rawdata.id);
     var remote = protocolIsValid(uri.protocol) === 'remote';
-    var loaded;
 
     if (source.tmpid(id)) return callback(new Error('Cannot save temporary source ' + id));
     if (remote) return callback(new Error('Cannot save remote source ' + id));
 
-    source.refresh(rawdata, invalidate);
+    source.refresh(rawdata, done);
 
-    function invalidate(err, l) {
-        if (err) return callback(err);
-        loaded = l;
-        source.invalidate(id, done);
-    }
-
-    function done(err) {
+    function done(err, loaded) {
         if (err) return callback(err);
         var data = loaded.data;
         var xml = loaded.xml;


### PR DESCRIPTION
Refresh should always invalidate local sources. Lost in save/refresh split.

cc @samanpwbb 
