### PR TITLE
fix search interactions

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -693,16 +693,25 @@ body.local .on-local { display:block; }
         .CodeMirror-gutter-wrapper .error > a:target ~ .message { display:inline-block; }
 
 /* CodeMirror Addon: Search Dialog */
-.CodeMirror-dialog,
-.CodeMirror-dialog * {
-  box-sizing:border-box;
-  }
-.CodeMirror .CodeMirror-dialog { top:-40px; }
-.CodeMirror .hidden:target { display:block; }
+.CodeMirror-dialog input {
+  padding-left: 40px;
+  padding-right: 40px;
+}
 
-.CodeMirror #search-info ~ .dialog-y,
-.CodeMirror #search-info:target ~ .dialog-n { display: none;}
-.CodeMirror #search-info:target ~ .dialog-y { display: block;}
+.CodeMirror-dialog .search-buttons {
+  right: 40px;
+}
+
+.CodeMirror-dialog .search-buttons a:last-child { border-radius: 3px; }
+.CodeMirror-dialog .search-buttons.reset a:last-child { border-radius: 0 3px 3px 0;}
+.CodeMirror-dialog .search-buttons.reset a { display: inline-block;}
+
+#search-info ~ .dialog-y,
+#search-info:target ~ .dialog-n { display: none;}
+#search-info:target ~ .dialog-y { display: block;}
+
+.CodeMirror-dialog .hidden:target { display:block; }
+
 /* CodeMirror Addon: palette swatch */
 .CodeMirror .cm-palette-hint {
   display:inline-block;

--- a/app/codemirror.tm2.search.js
+++ b/app/codemirror.tm2.search.js
@@ -12,37 +12,46 @@
 })(function (CodeMirror) {
     'use strict';
 
-    function dialogDiv(cm, template) {
-        var wrap = cm.getWrapperElement();
-
-        var past = document.getElementById('dialog');
-        if (past) past.parentNode.removeChild(past);
-
-        var dialog;
-        dialog = wrap.appendChild(document.createElement('div'));
-        dialog.id = 'dialog';
-        dialog.className = 'CodeMirror-dialog fill-white keyline-bottom pin-top z100';
-
-        if (typeof template == 'string') {
-            dialog.innerHTML = template;
-        } else {
-            // Assuming it's a detached DOM element.
-            dialog.appendChild(template);
-        }
-        return dialog;
-    }
-
-    CodeMirror.defineExtension('openDialog', function (template, callback) {
-        var dialog = dialogDiv(this, template);
-        var inp = document.getElementsByClassName('js-search-input')[0],
-            info = document.getElementsByClassName('js-cm-dialog-info')[0],
+    CodeMirror.defineExtension('openDialog', function (callback) {
+        var dialog = document.getElementsByClassName('CodeMirror-dialog')[0],
+            inp = document.getElementsByClassName('js-search-input')[0],
             exit = document.getElementsByClassName('js-cm-dialog-close')[0],
+            buttonWrap = document.getElementsByClassName('js-search-buttons')[0],
             button = document.getElementsByClassName('js-cm-search-button')[0],
-            me = this;
+            reset = document.getElementsByClassName('js-cm-reset-button')[0],
+            me = this,
+            state = getSearchState(me);
+
+
+        if (!dialog.classList.contains('active')) {
+            dialog.classList.add('active');
+        }
 
         function close() {
-            if (dialog.parentNode) dialog.parentNode.removeChild(dialog);
+            dialog.classList.remove('active');
             clearSearch(me);
+            inp.blur();
+        }
+
+        function fail() {
+            buttonWrap.classList.add('reset');
+        }
+
+        function search() {
+            callback(inp.value);
+            if (state.overlay.count) {
+                buttonWrap.classList.remove('reset');
+                me.focus();
+            } else {
+                fail();
+            }
+        }
+
+        function searchReset() {
+            clearSearch(me);
+            inp.value = '';
+            inp.focus();
+            buttonWrap.classList.remove('reset');
         }
 
         CodeMirror.on(exit, 'click', function() {
@@ -50,25 +59,21 @@
         });
 
         CodeMirror.on(document, 'keydown', function(e) {
-            if (e.keyCode === 27) close();
+            if (e.keyCode === 27) close(); // esc
         });
 
         CodeMirror.on(inp, 'keydown', function(e) {
             if (e.keyCode === 13 || (e.keyCode === 71 && e.metaKey) || (e.keyCode === 70 && e.metaKey)) {
-                inp.blur();
-                CodeMirror.e_stop(e);
-                me.focus();
-                callback(inp.value);
+                search();
             }
         });
 
         CodeMirror.on(button, 'click', function(e) {
-            // if a search is already underway, button finds next
-            if (me.state.search.query === inp.value) {
-                findNext(me);
-            } else {
-                callback(inp.value);
-            }
+            search();
+        });
+
+        CodeMirror.on(reset, 'click', function(e) {
+            searchReset();
         });
 
         inp.focus();
@@ -77,6 +82,8 @@
     });
 
     function searchOverlay(query, caseInsensitive) {
+        var count = 0;
+
         var startChar;
         if (typeof query == 'string') {
             startChar = query.charAt(0);
@@ -85,16 +92,25 @@
         } else {
             query = new RegExp('^(?:' + query.source + ')', query.ignoreCase ? 'i' : '');
         }
-        return {
-            token: function (stream) {
-                if (stream.match(query)) return 'searching';
-                while (!stream.eol()) {
-                    stream.next();
-                    if (startChar && !caseInsensitive)
-                        stream.skipTo(startChar) || stream.skipToEnd();
-                    if (stream.match(query, false)) break;
+
+        var token = function (stream) {
+            if (stream.match(query)) {
+                count = count + 1;
+                this.count = count
+                return 'searching';
+            }
+            while (!stream.eol()) {
+                stream.next();
+                if (startChar && !caseInsensitive)
+                    stream.skipTo(startChar) || stream.skipToEnd();
+                if (stream.match(query, false)) {
+                    break;
                 }
             }
+        };
+
+        return {
+            token: token
         };
     }
 
@@ -127,24 +143,10 @@
         return query;
     }
 
-    var infoText = '<div id="search-info" class="clearfix keyline-top small fill-white search-info hidden">'+
-        '<div class="pad1 col6">'+
-          '<div class="code"><kbd class="prefixed">F</kbd> Find</div>'+
-          '<div class="code"><kbd class="prefixed">G</kbd> Next result</div>'+
-        '</div>' +
-        '<div class="pad1 col6">'+
-          '<div class="quiet">use /re/ syntax for regex search.</div>'+
-          '<div class="code"><kbd class="prefixed">Shift+G</kbd> Previous result</div>'+
-        '</div>' +
-    '</div>';
-    var infoAndClose = "<a href='#search-info' class='js-cm-dialog-info pin-topleft pad1 inline icon info quiet dialog-n'></a><a href='#' class='js-cm-dialog-info pin-topleft pad1 inline icon info fill-darken2 dark dialog-y'></a><a href='#' id='js-cm-dialog-close' class='js-cm-dialog-close pin-right pad1 inline icon x quiet'></a></div>";
-    var queryButton = "<div class='pin-topright pad0y'><a href='#' class='js-cm-search-button button short icon small quiet search'>Find</a></div>"
-    var queryDialog = "<div class='fill-white z10 pad4x'><fieldset class='keyline-left contain'><input type='text' placeholder='Search stylesheet' value='' class='js-search-input clean stretch'>" + queryButton + "</fieldset></div>" + infoText + infoAndClose;
-
     function doSearch(cm, rev) {
         var state = getSearchState(cm);
         if (state.query) return findNext(cm, rev);
-        cm.openDialog(queryDialog, function (query) {
+        cm.openDialog(function (query) {
             cm.operation(function () {
                 if (state.query && state.query !== query) state.query = query;
                 state.query = parseQuery(query);

--- a/templates/history.html
+++ b/templates/history.html
@@ -12,7 +12,7 @@
     <a class='short js-browseproject button col12 icon folder'>Browse</a>
   </div>
 
-  <div class='center pad1x space-bottom1'>
+  <div class='center pad1 keyline-top'>
     <div class='inline col12 rounded-toggle'><!--
     --><a class='js-tab strong col6 <%= obj.style  ? 'active' : '' %>' href='#history-style'>Styles</a><!--
     --><a class='js-tab strong col6 <%= obj.source ? 'active' : '' %>' href='#history-source'>Sources</a>

--- a/templates/style.html
+++ b/templates/style.html
@@ -306,6 +306,31 @@
         <a href='#export' class='inline js-export export-n icon picture keyline-left quiet pad1'></a>
       </div>
     </div>
+    <div class='CodeMirror-dialog offcanvas-top animate fill-white keyline-bottom pin-top z100'>
+      <div class='fill-white z10'>
+        <fieldset class='keyline-left contain'>
+          <input type='text' placeholder='Search stylesheet' value='' class='search-input small js-search-input clean stretch'>
+          <div class='pin-topright pad0y pill search-buttons js-search-buttons'>
+            <a href='#' class='js-cm-reset-button button short icon small quiet alert reset-button hidden'>No results</a><!--
+            --><a href='#' class='js-cm-search-button button short icon small quiet search'>Find</a>
+          </div>
+        </fieldset>
+      </div>
+      <div id="search-info" class="clearfix keyline-top small fill-white search-info hidden">
+        <div class="pad1 col6">
+          <div class="code"><kbd class="prefixed">F</kbd> Find</div>
+          <div class="code"><kbd class="prefixed">G</kbd> Next result</div>
+        </div>
+        <div class="pad1 col6">
+          <div class="quiet">use /re/ syntax for regex search.</div>
+          <div class="code"><kbd class="prefixed">Shift+G</kbd> Previous result</div>
+        </div>
+      </div>
+      <a href='#search-info' class='js-cm-dialog-info pin-topleft pad1 inline icon info quiet dialog-n'></a>
+      <a href='#' class='js-cm-dialog-info pin-topleft pad1 inline icon info quiet active dialog-y'></a>
+      <a href='#' id='js-cm-dialog-close' class='js-cm-dialog-close pin-right pad1 inline icon x quiet'></a>
+
+    </div>
     <div id='stylesheets'></div>
   </div>
 


### PR DESCRIPTION
More intuitive code search:
![2014-09-20 18_31_02](https://cloud.githubusercontent.com/assets/108094/4346787/d7e8bd04-4115-11e4-87a9-e1ca8c011fb2.gif)

Fix #735
- Moves search dom elements out of codemirror and into main style template
- Search input persists if user dismisses and then re-triggers search
- If no match, 'no results' notice appears
- If no match, focus stays on search input
- Clicking 'no results' resets search input and clears notice. Otherwise, a new successful search will clear the notice.

Todo: 
- [ ] Add tests
