### PR TITLE
Pin gazetteer to 0.1.2 until ready for 0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "abaculus": "0.0.5",
     "progress-stream": "0.5.0",
     "safer-stringify": "0.0.1",
-    "gazetteer": "0.1.x"
+    "gazetteer": "0.1.2"
   },
   "devDependencies": {
     "tape": "2.13.x",


### PR DESCRIPTION
We've got some tests that are expecting the data in 0.1.2. @nickidlugash will update them when 0.1.3+ is ready.
