### PR TITLE
Dedupe

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "url": "git://github.com/mapbox/mapbox-studio.git"
   },
   "dependencies": {
+    "node-pre-gyp": "0.5.27",
     "log-rotate": "0.2.x",
     "through": "2.3.x",
     "queue-async": "1.0.x",
@@ -23,14 +24,14 @@
     "minimist": "0.1.x",
     "underscore": "1.4.x",
     "tilejson": "0.10.0",
-    "mbtiles": "0.5.0",
+    "mbtiles": "0.6.0",
     "mkdirp": "0.5.x",
     "dirty": "0.9.9",
     "sphericalmercator": "1.0.x",
     "js-yaml": "https://github.com/mapbox/js-yaml/tarball/scalar-styles",
     "fstream": "0.1.x",
     "tar": "0.1.x",
-    "mapnik": "1.4.15",
+    "mapnik": "1.4.17",
     "mapnik-reference": "~6.0.1",
     "carto": "0.14.0",
     "speedometer": "0.1.2",
@@ -69,6 +70,7 @@
   "scripts": {
     "start": "./index.js",
     "preinstall": "node scripts/run.js scripts/vendor-node.sh",
+    "postinstall": "npm dedupe node-pre-gyp",
     "test": "tape test/*.test.js",
     "posttest": "node test/cleanup.js"
   }

--- a/scripts/build-atom.sh
+++ b/scripts/build-atom.sh
@@ -85,7 +85,7 @@ node_modules/mapnik-omnivore/node_modules/gdal"
 for module in $modules; do
     rm -r $app_dir/$module/lib/binding
     cd $app_dir/$module
-    ./node_modules/.bin/node-pre-gyp install \
+    $app_dir/node_modules/.bin/node-pre-gyp install \
         --target_platform=$platform \
         --target=$node_version \
         --target_arch=$arch \


### PR DESCRIPTION
Dedupes node-pre-gyp dependencies for shorter filepaths on Windows. Fixes #611.
