### PR TITLE
atom-specific loading modal for image exports

### DIFF
--- a/app/atom.js
+++ b/app/atom.js
@@ -38,11 +38,15 @@ $(document).ready(function() {
                 filters: [{ name: typeExtension.toUpperCase(), extensions: [typeExtension]}]
             });
             if (filePath) {
+                window.Modal.show('atomexporting');
                 uri.method = 'GET';
                 var writeStream = fs.createWriteStream(filePath);
                 var req = http.request(uri, function(res) {
                     if (res.statusCode !== 200) return;
                     res.pipe(writeStream);
+                    writeStream.on('finish', function() {
+                        window.Modal.close();
+                    });
                 });
                 req.end();
             }
@@ -50,4 +54,11 @@ $(document).ready(function() {
         }
         // Passthrough everything else.
     });
+
+    window.Modal.options.templates.modalatomexporting = function() { return "\
+    <div id='atom-loading' class='modal round col6 margin3 pin-top top2 dark fill-dark'>\
+        <h3 class='center pad1y pad2x keyline-bottom'>Exporting</h3>\
+        <div class='row2 loading contain'></div>\
+    </div>";
+    };
 });


### PR DESCRIPTION
![atom-loading](https://cloud.githubusercontent.com/assets/83384/4486825/6ae1a942-49ed-11e4-97d8-5ccd7586be53.gif)

Refs #874. Stopgap -- meant to address the lack of any visual feedback that atom is up to something (downloading the export image).
