### PR TITLE
Document min platforms supported in more detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,34 @@ Install [node v0.10.x](http://nodejs.org/download/). Then
     npm install
     npm start
 
-*Note: the binary dependencies of Mapbox Studio are now prebuilt for common platforms (64 bit Linux and OS X). This means that you do not need to install these dependencies externally. However if packages fail to install from a binary then you are likely running a platform for which no binaries are available. In this case you will need to build these packages from source.*
+### Depends
+
+Mapbox Studio ships with pre-built binaries for common platforms:
+
+  - 32 and 64 bit Windows
+  - 64 bit OS X
+  - 64 bit Linux
+
+The minimum platforms versions are:
+
+  - Windows >= 7
+  - OS X >= 10.9
+  - Ubuntu >= 14.04 (Trusty)
+  - RHEL/Centos >= 7
+
+Note: Ubuntu 12.04 (Precise) can be supported by upgrading libstdc++:
+
+    sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    sudo apt-get update -q
+    sudo apt-get install -y libstdc++6
+
+Note: if packages like `node-mapnik` fail to install then you are likely running a platform for which no binaries are available. In this case you will need to build these packages from source (Feel free to create a github issue to ask for help).
+
+You can do this like:
+
+
+    npm install --build-from-source
+
 
 ### Getting started
 


### PR DESCRIPTION
To be merged once Mapnik 3.x is used. Basically:
- c++11 requirement means only recent linux is supported via binaries
- OS X requirement of 10.9 is due to LTO (link time optimization) used to compile binaries. While I could drop this to be able to support 10.8 I'd prefer to target 10.9 unless a lot of people complain because it will allow faster and smaller binaries for Mapnik on >= 10.9
- Not sure if the min Windows version has changed, so just guessing >= 7 is needed, but vista and XP might actually work
  - refs https://github.com/mapnik/node-mapnik/issues/324
