### PR TITLE
fix double space after autocomplete

### DIFF
--- a/app/codemirror.carto.complete.js
+++ b/app/codemirror.carto.complete.js
@@ -108,6 +108,27 @@
             // If this is not on a token that's autocompletable,
             // insert a tab.
             if (!/(@|#|\.)?[\w-$_]+$/.test(token.string)) {
+
+                if (e.which === 9 && !e.shiftKey) {
+                    // tab forwards
+                    editor.replaceRange('  ', {
+                        line: cur.line,
+                        ch: cur.ch
+                    }, {
+                        line: cur.line,
+                        ch: cur.ch
+                    });
+                } else {
+                    // tab backwards
+                    editor.replaceRange('', {
+                        line: cur.line,
+                        ch: cur.ch - 2
+                    }, {
+                        line: cur.line,
+                        ch: cur.ch
+                    });
+                }
+
                 editor.focus();
                 return !/^\s*$/.test(token.string);
             }
@@ -203,8 +224,8 @@
                     sel.selectedIndex = (--sel.selectedIndex === -1) ?
                         sel.size - 1 :
                         sel.selectedIndex;
-                // Escape
-                } else if (code === 27) {
+                // Escape & delete
+                } else if (code === 27 || code === 46) {
                     cancelEvent(event);
                     close();
                     editor.focus();
@@ -238,6 +259,7 @@
             onKeyEvent: function(i, e) {
                 // Hook into tab
                 if (e.which == 9 && !(e.ctrlKey || e.metaKey) && !e.altKey) {
+                    cancelEvent(e);
                     return complete(e);
                 }
             },

--- a/app/style.js
+++ b/app/style.js
@@ -38,14 +38,6 @@ var Modal = window.Modal = new views.Modal({
   templates: templates
 });
 
-CodeMirror.keyMap.tabSpace = {
-  Tab: function(cm) {
-    var spaces = Array(cm.getOption('indentUnit') + 1).join(' ');
-    cm.replaceSelection(spaces, 'end', '+input');
-  },
-  fallthrough: ['default']
-};
-
 var Tab = function(id, value) {
   var tab = CodeMirror(function(cm) {
     document.getElementById('stylesheets').appendChild(cm);
@@ -57,8 +49,7 @@ var Tab = function(id, value) {
     mode: {
       name: 'carto',
       reference: window.cartoRef
-    },
-    keyMap: 'tabSpace'
+    }
   });
 
   var completer = cartoCompletion(tab, window.cartoRef);


### PR DESCRIPTION
The tab event was being preserved through the autocomplete function and applied at the end, resulting in two spaces after every autocomplete. Made changes so tab events are totally handled inside `carto.complete.js` now.
