### PR TITLE
Fix crash when uploading postgis source

### DIFF
--- a/lib/source.js
+++ b/lib/source.js
@@ -306,6 +306,9 @@ source.extent = function(data) {
         var results = getExtent(ds, l.srs);
         var extent = results.extent;
 
+        // Unsupported format or other error from omnivore
+        if (!extent) return memo;
+
         // Take the greater coordinate to make sure all layers are included in the final extent
         memo[0] = Math.max(-180, Math.min(extent[0], memo[0]));
         memo[1] = Math.max(-85.0511, Math.min(extent[1], memo[1]));


### PR DESCRIPTION
Mapbox-studio crashes when uploading a source if mapnik-omnivore does not support the source format.

mapnik-omnivore does not support postgis, and returns null for the extents of the data. This patch sidesteps the issue and allows the upload to complete. The user will want to manually specify the extent for the layer.

Back trace:

```
/mapbox-studio-linux-x64-v0.1.6/resources/app/lib/source.js:310
        memo[0] = Math.max(-180, Math.min(extent[0], memo[0]));
                                                ^
TypeError: Cannot read property '0' of undefined
    at /mapbox-studio-linux-x64-v0.1.6/resources/app/lib/source.js:310:49
    at Array.reduce (native)
    at Function.source.extent (/mapbox-studio-linux-x64-v0.1.6/resources/app/lib/source.js:297:35)
    at copy (/mapbox-studio-linux-x64-v0.1.6/resources/app/lib/source.js:710:47)
    at /mapbox-studio-linux-x64-v0.1.6/resources/app/lib/source.js:703:13
    at source (/mapbox-studio-linux-x64-v0.1.6/resources/app/lib/source.js:97:27)
    at loadf (/mapbox-studio-linux-x64-v0.1.6/resources/app/lib/source.js:699:9)
    at Function.source.uploadStream (/mapbox-studio-linux-x64-v0.1.6/resources/app/lib/source.js:695:5)
    at startUpload (/mapbox-studio-linux-x64-v0.1.6/resources/app/lib/source.js:682:25)
    at /mapbox-studio-linux-x64-v0.1.6/resources/app/lib/source.js:656:17

```
