### PR TITLE
User fonts

### DIFF
--- a/docs/0000-01-01-advanced-features.md
+++ b/docs/0000-01-01-advanced-features.md
@@ -3,6 +3,7 @@ Advanced features
 
 - [UTFGrid interactivity](#utfgrid-interactivity)
 - [Custom layer order](#custom-layer-order)
+- [Custom fonts](#custom-fonts)
 
 UTFGrid interactivity
 ---------------------
@@ -51,3 +52,17 @@ Once the **layers** key is added to a style project the source can only be chang
 _This source is locked in the UI because of a custom layer order defined in `project.yml`_
 
 _Note: After making edits to the `project.yml` file in a text editor you should quit and restart Mapbox Studio to see your changes. Studio loads up your project into memory and currently does not detect changes from other text editors._
+
+Custom fonts
+------------------
+
+It's possible to use your own fonts in Mapbox Studio styles. First of all, include your `woff`, `.ttf`, `.otf` font file in a style's project directory. Secondly, create a reference to where the fonts are located in carto:
+
+``` CSS
+    Map {
+      /* assumes fonts are in the style project's base directory */
+      font-directory: url('');
+    }
+```
+
+Once you've included fonts in your project and defined a font directory, you can then use the fonts by name anywhere in your style and they will be packaged with the style when uploaded to Mapbox or exported as a `.tm2z`. Make sure you only use fonts that are licensed for web usage.

--- a/lib/style.js
+++ b/lib/style.js
@@ -443,6 +443,7 @@ style.toPackage = function(id, dest, callback) {
                 if (info.props.type === 'Directory') return true;
                 if (info.props.basename.toLowerCase() === 'project.xml') return true;
                 var extname = path.extname(info.props.basename).toLowerCase();
+                if (/.woff|.ttf|.otf|.ttc|.pfa|.pfb|.dfont/.test(extname)) return true;
                 if (extname === '.png') return true;
                 if (extname === '.jpg') return true;
                 if (extname === '.svg') return true;

--- a/templates/style.html
+++ b/templates/style.html
@@ -263,7 +263,7 @@
     </div>
     <div id='fontfamily' class='pin-left col12 top1 scroll-styled'>
       <%= this['stylefonts'](fontsRef) %>
-      <div class='pad1 quiet small'>To use your own fonts, add them to your project folder and define a <code class='micro'>font-directory</code> on the <code class='micro'>Map</code> element.</div>
+      <div class='pad1 quiet small'>To use your own fonts, include them in your projects's directory and define a <code class='micro'>font-directory</code> on the <code class='micro'>Map</code> element.</div>
     </div>
   </div>
 

--- a/templates/style.html
+++ b/templates/style.html
@@ -262,7 +262,8 @@
       <a href='#' class='icon x pin-right pad1 quiet'></a>
     </div>
     <div id='fontfamily' class='pin-left col12 top1 scroll-styled'>
-    <%= this['stylefonts'](fontsRef) %>
+      <%= this['stylefonts'](fontsRef) %>
+      <div class='pad1 quiet small'>To use your own fonts, add them to your project folder and define a <code class='micro'>font-directory</code> on the <code class='micro'>Map</code> element.</div>
     </div>
   </div>
 

--- a/templates/xrayfont.xml
+++ b/templates/xrayfont.xml
@@ -3,7 +3,7 @@
   <Style name='font'>
     <Rule>
       <TextSymbolizer
-        size='26'
+        size='24'
         fill='#fff'
         clip='false'
         face-name='<%=obj.name%>'

--- a/test/tm.test.js
+++ b/test/tm.test.js
@@ -170,9 +170,9 @@ test('tm font (invalid)', function(t) {
 test('tm font (valid)', function(t) {
     tm.font('Source Sans Pro Bold', '', function(err, buffer) {
         t.ifError(err);
-        t.ok(buffer.length > 1200 && buffer.length < 2000);
+        t.ok(buffer.length > 1200 && buffer.length < 2000, ' valid font size');
         setTimeout(function() {
-            t.ok(fs.existsSync(path.join(tm.config().cache, 'font-6310313b.png')));
+            t.ok(fs.existsSync(path.join(tm.config().cache, 'font-f574c8c3.png')));
             t.end();
         }, 2000);
     });
@@ -181,7 +181,7 @@ test('tm font (valid)', function(t) {
 test('tm font (cache hit)', function(t) {
     tm.font('Source Sans Pro Bold', '', function(err, buffer) {
         t.ifError(err);
-        t.ok(buffer.length > 1200 && buffer.length < 2000);
+        t.ok(buffer.length > 1200 && buffer.length < 2000, ' valid font size');
         t.ok(buffer.hit);
         t.end();
     });


### PR DESCRIPTION
Does four things:
- Packages font files with .tm2z
- Smaller font display in sidebar to fix broken fonts (sort of unrelated)
- Adds documentation in `advanced-features` on using custom fonts
- Adds note about custom fonts in font sidebar:
  
  ![screen_shot_2014-10-28_at_6_14_33_pm](https://cloud.githubusercontent.com/assets/108094/4818222/c3ddfe34-5ef0-11e4-9a94-4ca0adecc1a2.png)

cc: @yhahn 
