### PR TITLE
Validation of C++ binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_install:
 
 install:
 - npm install --fallback-to-build=false
+- python test/check_shared_libs.py node_modules/
 
 before_script:
  - npm ls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,9 @@ install:
   - npm -v
   - if "%msvs_toolset%" == "12" npm install --fallback-to-build=false
   - if "%msvs_toolset%" == "14" npm install --fallback-to-build=false --toolset=v140
+  # put dumpbin on path: required by check_shared_libs.py
+  - SET PATH=C:\Program Files (x86)\MSBuild\12.0\bin;%PATH%
+  - if "%msvs_toolset%" == "14" python test\check_shared_libs.py .\
   - npm test
   - node test/test-client.js
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,7 @@ install:
   - if "%msvs_toolset%" == "14" npm install --fallback-to-build=false --toolset=v140
   # put dumpbin on path: required by check_shared_libs.py
   - SET PATH=C:\Program Files (x86)\MSBuild\12.0\bin;%PATH%
+  - SET PATH=C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin;%PATH%
   - if "%msvs_toolset%" == "14" python test\check_shared_libs.py .\
   - npm test
   - node test/test-client.js

--- a/test/check_shared_libs.py
+++ b/test/check_shared_libs.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import fnmatch
+import platform
+import subprocess
+
+if len(sys.argv) < 2:
+    sys.stderr.write('please pass the path to a directory to search\n')
+    exit(1)
+
+matches = []
+for root, dirnames, filenames in os.walk(sys.argv[1]):
+  if platform.system() == 'Windows':
+      for filename in fnmatch.filter(filenames, 'node.exe'):
+          matches.append(os.path.join(root, filename))
+  else:
+      for filename in fnmatch.filter(filenames, 'node'):
+          matches.append(os.path.join(root, filename))
+  for filename in fnmatch.filter(filenames, '*.node'):
+      matches.append(os.path.join(root, filename))
+  if platform.system() == 'Windows':
+      for filename in fnmatch.filter(filenames, '*.dll'):
+          matches.append(os.path.join(root, filename))
+  elif platform.system() == 'Darwin':
+      for filename in fnmatch.filter(filenames, '*.dylib'):
+          matches.append(os.path.join(root, filename))
+  elif platform.system() == 'Linux':
+      for filename in fnmatch.filter(filenames, '*.so'):
+          matches.append(os.path.join(root, filename))
+
+returncode = 0;
+
+for match in matches:
+    lib_returncode = 0
+    if platform.system() == 'Windows':
+        #call = subprocess.Popen(['dumpbin', '/DIRECTIVES', match],stdout=subprocess.PIPE)
+        #print call.communicate()[0]
+        call = subprocess.Popen(['dumpbin', '/DEPENDENTS', match], stdout=subprocess.PIPE)
+        result = call.communicate()[0]
+        bad_checks = ['LIBCMT','MSVCRTD','MSVCP120.dll']
+        for bad_check in bad_checks:
+            if bad_check in result:
+                lib_returncode = 1
+                sys.stderr.write('%s found in %s\n' % (bad_check,match))
+        good_checks = ['VCRUNTIME140.dll','APPCRT140.dll','DESKTOPCRT140.dll']
+        # these two libs do not link to anything
+        exceptions = ['icudt53.dll','icudt54.dll','libexpat.dll']
+        found_one = False
+        for good_check in good_checks:
+            if good_check in result:
+                found_one = True
+        if not found_one and os.path.basename(match) not in exceptions:
+            sys.stderr.write('vs140 runtimes not found in %s\n' % (match))
+            lib_returncode = 1
+    elif platform.system() == 'Darwin':
+        call = subprocess.Popen(['otool', '-L', match], stdout=subprocess.PIPE)
+        result = call.communicate()[0]
+        if '/usr/local' in result:
+            lib_returncode = 1
+            sys.stderr.write('/usr/local found in %s' % match)
+    elif platform.system() == 'Linux':
+        call = subprocess.Popen(['ldd', match], stdout=subprocess.PIPE)
+        result = call.communicate()[0]
+        if '/usr/local' in result:
+            lib_returncode = 1
+            sys.stderr.write('/usr/local found in %s' % match)
+    if lib_returncode == 0:
+        sys.stdout.write('✓ %s is all good\n' % os.path.basename(match))
+    else:
+        returncode = lib_returncode
+        sys.stderr.write('%s is broken\n' % os.path.basename(match))
+
+exit(returncode)
+


### PR DESCRIPTION
Appveyor is down, but tested this locally, for builds with `--toolset=v140` this should pass. This should fail in the following scenarios:
- vendorized node.exe for windows is not from [node-cpp11](https://github.com/mapbox/node-cpp11)
- any native modules get built incorrectly (built with either /MT or built against a runtime that is not Visual Studio 2014)

The validation focus of this script is windows, but could be extended further for linux and osx in the future.
