### PR TITLE
Disable links to windows installers

### DIFF
--- a/website/_includes/download.html
+++ b/website/_includes/download.html
@@ -13,17 +13,17 @@
             <small>150MB download for OS X</small>
         </span>
     </a>
-    <a href='https://mapbox.s3.amazonaws.com/mapbox-studio/mapbox-studio-win32-x86-{{site.release}}.exe' class='pin-top button row2 pad2 fill-green space clip on-win32'>
+    <a class='pin-top button row2 pad2 fill-green space clip on-win32'>
         <div class='align-top inline row1 icon big down dot fill-darken1'></div>
         <span class='inline row1 text-left'>
-            <h3>mapbox-studio-win32-x86-{{site.release}}.exe</h3>
+            <h3>Windows installer is temporarily unavailable</h3>
             <small>100MB download for Windows</small>
         </span>
     </a>
-    <a href='https://mapbox.s3.amazonaws.com/mapbox-studio/mapbox-studio-win32-x64-{{site.release}}.exe' class='pin-top button row2 pad2 fill-green space clip on-win64'>
+    <a class='pin-top button row2 pad2 fill-green space clip on-win64'>
         <div class='align-top inline row1 icon big down dot fill-darken1'></div>
         <span class='inline row1 text-left'>
-            <h3>mapbox-studio-win32-x64-{{site.release}}.exe</h3>
+            <h3>Windows installer is temporarily unavailable</h3>
             <small>100MB download for Windows</small>
         </span>
     </a>


### PR DESCRIPTION
One user has reported the uninstaller removing data that it should not remove. Until we can figure out the problem exactly I'm pulling the installers.
