### PR TITLE
Handle errors when compacting broken db. Refs #1062.

### DIFF
--- a/lib/tm.js
+++ b/lib/tm.js
@@ -102,6 +102,7 @@ tm.dbcompact = function(filepath, callback) {
     // Read the old db into memory.
     function readold() {
         var old = dirty(filepath);
+        old.on('error', function(err) { console.warn('tm.dbcompact: ' + err.toString()); });
         old.once('read_close', compact);
         old.once('load', function() {
             old.forEach(function(k,v) { olddb[k] = v; });

--- a/test/fixtures-dirty/broken.db
+++ b/test/fixtures-dirty/broken.db
@@ -1,0 +1,12 @@
+{"key":"test","val":1}
+{"key":"test","val":2}
+{"key":"test","val":3},
+{"key":"test","val":4}
+{"key":"test","val":1}
+{"key":"test","val":2}
+{"key":"test","val":3}
+{"key":"test","val":4}
+{"key":"test","val":1}
+{"key":"test","val":2}
+{"key":"test","val":3}
+{"key":"test","val":4}

--- a/test/tm.test.js
+++ b/test/tm.test.js
@@ -20,6 +20,7 @@ test('setup: config', function(t) {
 
 test('setup: db', function(t) {
     fs.writeFileSync(path.join(tmppath, 'noncompact.db'), fs.readFileSync(path.join(__dirname, 'fixtures-dirty', 'noncompact.db')));
+    fs.writeFileSync(path.join(tmppath, 'broken.db'), fs.readFileSync(path.join(__dirname, 'fixtures-dirty', 'broken.db')));
     fs.writeFileSync(path.join(tmppath, 'schema-v1.db'), fs.readFileSync(path.join(__dirname, 'fixtures-dirty', 'schema-v1.db')));
     fs.writeFileSync(path.join(tmppath, 'schema-v2.db'), fs.readFileSync(path.join(__dirname, 'fixtures-dirty', 'schema-v2.db')));
     fs.writeFileSync(path.join(tmppath, 'schema-v3.db'), fs.readFileSync(path.join(__dirname, 'fixtures-dirty', 'schema-v3.db')));
@@ -68,6 +69,17 @@ test('tm compacts nofile', function(t) {
             t.equal(23, fs.statSync(dbpath).size);
             t.end();
         });
+    });
+});
+
+test('tm compacts broken', function(t) {
+    var dbpath = path.join(tmppath, 'broken.db');
+    t.equal(277, fs.statSync(dbpath).size);
+    tm.dbcompact(dbpath, function(err, db) {
+        t.ifError(err);
+        t.equal(db.get('test'), 4, 'has right value');
+        t.equal(23, fs.statSync(dbpath).size);
+        t.end();
     });
 });
 


### PR DESCRIPTION
Adds handler for `error` event on compaction allowing dbs with errors to be handled gracefully.

cc @springmeyer @BergWerkGIS 
