### PR TITLE
Expose upload errors to UI

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -339,8 +339,8 @@ app.all('/upload.json', function(req, res, next) {
     source.upload(req.query.id, req.method === 'PUT', function(err, job){
         if (err && err.code) {
             res.send(err.code, err.message);
-        } else if (err) {
-            next(err);
+        } else if (err || job.err) {
+            next(err || job.err);
         } else {
            res.send(job);
         }


### PR DESCRIPTION
A quick attempt to address https://github.com/mapbox/mapbox-studio/issues/1081. Here's what I found:
- We are [catching errors](https://github.com/mapbox/mapbox-studio/blob/553dec530b89827dc0f119233ea78a6250759d27/lib/source.js#L729) and they end up getting [set on the task as `t.err`](https://github.com/mapbox/mapbox-studio/blob/553dec530b89827dc0f119233ea78a6250759d27/lib/task.js#L27-L30)
- [We are showing HTTP errors as a modal in the browser](https://github.com/mapbox/mapbox-studio/blob/mb-pages/app/export.js#L38-L40)
- We are missing some facility for turning the errors captured on a task into HTTP errors

I took the most obvious path of checking for a task error at the middleware level and passing it on to the error middleware if found. It ends up looking like this:

![](https://dl.dropboxusercontent.com/s/erz66c46tnv0lun/2015-01-11%20at%2012.12%20PM.png?dl=0)

This isn't perfect because:
- 500 internal server error from Studio is probably not appropriate but I am not sure what conventions Studio's HTTP API in terms of errors
- Closing the modal leaves you in the pending upload state rather than resetting the state of the upload screen.

Looking for guidance from @yhahn or @camilleanne on whether this is the correct approach.
