### PR TITLE
better error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+- Add shell.log and document log location.
+- Add timestamps and stacktraces to logs.
+
 ### 0.2.2
 
 - Update to node-mapnik 3.1.2.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,12 @@ A note on Windows: Windows builds of Mapbox Studio target Visual Studio 2014 and
  - The node installs from https://nodejs.org/download are not supported for Windows.
  - To release a new Mapbox Studio version for Windows against a new Node.js version Windows binaries need to first be built via the toolchain at https://github.com/mapbox/node-cpp11.
 
+### Logs
+
+Mapbox Studio has an application log and a shell log for error reporting and application messages for the Mapbox Studio server and Atom shell, respectively. On Linux and OSX, `app.log` and `shell.log` are located in `~/.mapbox-studio/`. On Windows, `app.log` and `shell.log` can be found in `C:\Users\<YOUR-USER-NAME>\.mapbox-studio`.
+
+On OSX, the logs can also be accessed to through the Help dropdown on the top menu bar.
+
 ### Pull requests
 
 Use PRs for everything but trivial changes and typos. Goals to strive for:

--- a/index-server.js
+++ b/index-server.js
@@ -2,11 +2,9 @@
 // In an ideal world this would be run in the same process/context of
 // atom-shell but there are many hurdles atm, see
 // https://github.com/atom/atom-shell/issues/533
-var logger = require('fastlog')('', 'debug', '<${timestamp}>');
 
 // increase the libuv threadpool size to 1.5x the number of logical CPUs.
 process.env.UV_THREADPOOL_SIZE = Math.ceil(Math.max(4, require('os').cpus().length * 1.5));
-
 process.title = 'mapbox-studio';
 
 if (process.platform === 'win32') {
@@ -15,10 +13,6 @@ if (process.platform === 'win32') {
     // NULL out PATH to avoid potential conflicting dlls
     process.env.PATH = '';
 }
-
-process.on('exit', function(code) {
-    console.warn('Mapbox Studio exited with', code + '.');
-});
 
 var tm = require('./lib/tm');
 var path = require('path');
@@ -30,6 +24,7 @@ config.shell = config.shell || false;
 config.port = config.port || undefined;
 config.test = config.test || false;
 config.cwd = path.resolve(config.cwd || process.env.HOME);
+var logger = require('fastlog')('', 'debug', '<${timestamp}>');
 
 var usage = function usage() {
   var str = [
@@ -51,12 +46,12 @@ var usage = function usage() {
 }
 
 if (config.version) {
-    console.log(package_json.version);
+    logger.debug(package_json.version);
     process.exit(0);
 }
 
 if (config.help || config.h) {
-    console.log(usage());
+    logger.debug(usage());
     process.exit(0);
 }
 
@@ -85,6 +80,6 @@ function listen(err) {
 function finish(err) {
     if (err) throw err;
     server.emit('ready');
-    console.log('Mapbox Studio @ http://localhost:'+tm.config().port+'/');
+    logger.debug('Mapbox Studio @ http://localhost:'+tm.config().port+'/');
 }
 

--- a/index-server.js
+++ b/index-server.js
@@ -2,6 +2,7 @@
 // In an ideal world this would be run in the same process/context of
 // atom-shell but there are many hurdles atm, see
 // https://github.com/atom/atom-shell/issues/533
+var logger = require('fastlog')('', 'debug', '<${timestamp}>');
 
 // increase the libuv threadpool size to 1.5x the number of logical CPUs.
 process.env.UV_THREADPOOL_SIZE = Math.ceil(Math.max(4, require('os').cpus().length * 1.5));
@@ -14,6 +15,10 @@ if (process.platform === 'win32') {
     // NULL out PATH to avoid potential conflicting dlls
     process.env.PATH = '';
 }
+
+process.on('exit', function(code) {
+    console.warn('Mapbox Studio exited with', code + '.');
+});
 
 var tm = require('./lib/tm');
 var path = require('path');

--- a/index-shell.js
+++ b/index-shell.js
@@ -37,10 +37,13 @@ function shellsetup(err){
     // Report crashes to our server.
     require('crash-reporter').start();
 
-    atom.on('window-all-closed', function() {
+    atom.on('window-all-closed', exit);
+    atom.on('will-quit', exit);
+
+   function exit() {
         if (server) server.kill();
         process.exit();
-    });
+    };
 
     atom.on('ready', makeWindow);
 };

--- a/index-shell.js
+++ b/index-shell.js
@@ -96,8 +96,6 @@ function loadURL() {
 function createMenu() {
     var template;
 
-    console.log('logging menu creation');
-
     if (process.platform == 'darwin') {
     template = [
       {

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,0 +1,41 @@
+var fs = require('fs');
+var through = require('through');
+var rotate = require('log-rotate');
+
+// Set up app logging to a file with rotation.
+module.exports = function(filepath, maxsize, callback) {
+    if (!filepath) return callback();
+
+    fs.stat(filepath, function(err, stat) {
+        if (err && err.code !== 'ENOENT') return callback(err);
+        if (stat && !stat.isFile()) return callback(new Error(filepath + ' is not a file'));
+        if (!err && stat && stat.size > maxsize) {
+            rotate(filepath, { compress: true }, function(err) {
+                if (err) return callback(err);
+                setup(0);
+            });
+        } else {
+            setup(stat && stat.size || 0);
+        }
+    });
+
+    function setup(offset) {
+        var logstream = fs.createWriteStream(filepath, {
+            flags: offset ? 'r+' : 'w',
+            start: offset
+        });
+        logstream.on('error', function (err) {
+            console.warn('Problem writing to logfile at ' + filepath);
+            return callback();
+        })
+        var pipeout = through();
+        var pipeerr = through();
+        pipeout.pipe(logstream);
+        pipeout.pipe(process.stdout);
+        pipeerr.pipe(logstream);
+        pipeerr.pipe(process.stderr);
+        process.__defineGetter__('stdout', function() { return pipeout; });
+        process.__defineGetter__('stderr', function() { return pipeerr; });
+        return callback();
+    }
+};

--- a/lib/server.js
+++ b/lib/server.js
@@ -20,6 +20,7 @@ var gazetteer = require('gazetteer');
 var carto = require('carto');
 var version = require('./../package.json').version.replace(/^\s+|\s+$/g, '');
 var nocache = Math.random().toString(36).substr(-8);
+var logger = require('fastlog')('debug', 'error', '${level} <${timestamp}>');
 var mapnik = require('mapnik');
 if (!carto.tree.Reference.setVersion(mapnik.versions.mapnik)) {
     throw new Error("Could not set mapnik version to " + mapnik.versions.mapnik);
@@ -531,7 +532,11 @@ app.use(function(err, req, res, next) {
     if (err && err.status === 401) return res.redirect('/unauthorize');
 
     // Log errors if not testing.
-    if (!tm.config().test) console.warn(500, req.method, req.url, err.toString());
+    if (!tm.config().test) {
+        err.method = req.method;
+        err.url = req.url;
+        logger.error('500', err);
+    }
 
     // Otherwise 500 for now.
     if (/application\/json/.test(req.headers.accept)) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -20,7 +20,7 @@ var gazetteer = require('gazetteer');
 var carto = require('carto');
 var version = require('./../package.json').version.replace(/^\s+|\s+$/g, '');
 var nocache = Math.random().toString(36).substr(-8);
-var logger = require('fastlog')('debug', 'error', '${level} <${timestamp}>');
+var logger = require('fastlog')('', 'debug', '<${timestamp}> ${level}');
 var mapnik = require('mapnik');
 if (!carto.tree.Reference.setVersion(mapnik.versions.mapnik)) {
     throw new Error("Could not set mapnik version to " + mapnik.versions.mapnik);

--- a/lib/tm.js
+++ b/lib/tm.js
@@ -10,8 +10,8 @@ var crypto = require('crypto');
 var fstream = require('fstream');
 var tilelive = require('tilelive');
 var existsSync = require('fs').existsSync || require('path').existsSync;
-var rotate = require('log-rotate');
-var through = require('through');
+
+var applog = require('./log');
 
 tilelive.protocols['mbtiles:'] = require('mbtiles');
 
@@ -45,7 +45,7 @@ tm.config = function(opts, callback) {
     mapnik.register_default_input_plugins();
 
     // Set up logging with rotation after 10e6 bytes.
-    tm.applog(tm.config().log, 10e6, function(err) {
+    applog(tm.config().log, 10e6, function(err) {
         if (err && callback) return callback(err);
         if (err) throw err;
         // Compact db.
@@ -128,44 +128,6 @@ tm.dbcompact = function(filepath, callback) {
         db.once('load', function() {
             return callback(null, db);
         });
-    }
-};
-
-// Set up app logging to a file with rotation.
-tm.applog = function(filepath, maxsize, callback) {
-    if (!filepath) return callback();
-
-    fs.stat(filepath, function(err, stat) {
-        if (err && err.code !== 'ENOENT') return callback(err);
-        if (stat && !stat.isFile()) return callback(new Error(filepath + ' is not a file'));
-        if (!err && stat && stat.size > maxsize) {
-            rotate(filepath, { compress: true }, function(err) {
-                if (err) return callback(err);
-                setup(0);
-            });
-        } else {
-            setup(stat && stat.size || 0);
-        }
-    });
-
-    function setup(offset) {
-        var logstream = fs.createWriteStream(filepath, {
-            flags: offset ? 'r+' : 'w',
-            start: offset
-        });
-        logstream.on('error', function (err) {
-            console.warn('Problem writing to logfile at ' + filepath);
-            return callback();
-        })
-        var pipeout = through();
-        var pipeerr = through();
-        pipeout.pipe(logstream);
-        pipeout.pipe(process.stdout);
-        pipeerr.pipe(logstream);
-        pipeerr.pipe(process.stderr);
-        process.__defineGetter__('stdout', function() { return pipeout; });
-        process.__defineGetter__('stderr', function() { return pipeerr; });
-        return callback();
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "abaculus": "1.1.0",
     "progress-stream": "0.5.0",
     "safer-stringify": "0.0.1",
-    "gazetteer": "0.1.4"
+    "gazetteer": "0.1.4",
+    "fastlog": "1.0.0"
   },
   "devDependencies": {
     "retire": "0.3.x",

--- a/test/tm.test.js
+++ b/test/tm.test.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var path = require('path');
 var assert = require('assert');
 var tm = require('../lib/tm');
+var applog = require('../lib/log');
 var dirty = require('dirty');
 var tmppath = tm.join(require('os').tmpdir(), 'mapbox-studio', 'tm-' + +new Date);
 var stream = require('stream');
@@ -304,14 +305,14 @@ test('tm copydir filter', function(t) {
 });
 
 test('tm applog noop', function(t) {
-    tm.applog(false, 1, function(err) {
+    applog(false, 1, function(err) {
         t.ifError(err, 'noop on no filepath');
         t.end();
     });
 });
 
 test('tm applog err: not a file', function(t) {
-    tm.applog(tmppath, 1, function(err) {
+    applog(tmppath, 1, function(err) {
         t.ok(/is not a file$/.test(err.toString()), 'error when filepath is not a file');
         t.end();
     });
@@ -320,7 +321,7 @@ test('tm applog err: not a file', function(t) {
 test('tm applog', function(t) {
     var filepath = tm.join(tmppath + '/app.log');
     t.ok(!fs.existsSync(filepath), 'app.log does not exist');
-    tm.applog(filepath, 10, function(err) {
+    applog(filepath, 10, function(err) {
         t.ifError(err);
         process.stdout.write('      stdout\n');
         process.stderr.write('      stderr\n');
@@ -332,7 +333,7 @@ test('tm applog', function(t) {
     });
 
     function rotates() {
-        tm.applog(filepath, 10, function(err) {
+        applog(filepath, 10, function(err) {
             t.ifError(err);
             t.ok(fs.existsSync(filepath + '.0.gz'), 'rotates app log to app.log.0.gz');
             process.stdout.write('      stdout\n');


### PR DESCRIPTION
will hit
- [x] #956
- [x] #1127
- [x] #1133 
- [x] #1117

Adds `shell.log` for logging errors and messages from Atom Shell. `shell.log` and `app.log` now have timestamped errors, stack traces, and log exit codes when the application quits or crashes. 
