### PR TITLE
Add links to postgis-manual

### DIFF
--- a/docs/0000-01-01-source-manual.md
+++ b/docs/0000-01-01-source-manual.md
@@ -87,4 +87,6 @@ You can drag and drop layers in the layer list to reorder them. The order they'r
 Advanced PostgreSQL Layers
 --------------------------
 
+Check out our [PostGIS Manual]({{site.baseurl}}/postgis-manual/) for more details on how to use PostGIS + SQL with Mapbox Studio to create fast, performant vector tiles.
+
 Have a look at the [Natural Earth Mapbox Studio project](https://github.com/mapbox/natural-earth-tm2) for a full Mapbox Studio source example, and advanced PostgreSQL tricks like having multiple tables in one layer and scale-aware queries.

--- a/website/_includes/docnav.html
+++ b/website/_includes/docnav.html
@@ -25,6 +25,10 @@
     <span class='dot inline icon book pad0 fill-purple'></span>
     <span class='pad0x'>Source manual</strong>
 </a>
+<a href='{{site.baseurl}}/postgis-manual/' class='block pad0 truncate'>
+    <span class='dot inline icon book pad0 fill-purple'></span>
+    <span class='pad0x'>PostGIS manual</strong>
+</a>
 <a href='{{site.baseurl}}/common-questions/' class='block pad0 truncate'>
     <span class='dot inline icon lifebuoy pad0 fill-orange'></span>
     <span class='pad0x'>Common questions</strong>


### PR DESCRIPTION
@pdgoodman @heyitsgarrett - Ready to merge...

Added links to PostGIS manual on [Mapbox Studio Source Manual page](https://www.mapbox.com/mapbox-studio/source-manual/#postgis)

![image](https://cloud.githubusercontent.com/assets/4587826/5905388/d30bf790-a55d-11e4-8235-711ce5d79258.png)

And footer navigation in Mapbox Studio section

![image](https://cloud.githubusercontent.com/assets/4587826/5905399/db621a32-a55d-11e4-9587-8de70e8e76e1.png)

/cc @geografa 
