### PR TITLE
local compositing language change

### DIFF
--- a/templates/modalsources.html
+++ b/templates/modalsources.html
@@ -38,7 +38,7 @@ if (active && active.id.indexOf('tmsource://') === 0) activeType = 'local';
         --><input class='col3' type='submit' value='Apply'/>
       </div>
       <div class='micro quiet center pad1y'>
-        To use a composite source, string together comma-separated map IDs.
+        Upload and host your local sources on mapbox.com to use them in composite sources.
       </div>
     </form>
   </div>


### PR DESCRIPTION
Changes the compositing language on the local sources modal from 

> To use a composite source, string together comma-separated map IDs.

to 

> Upload and host your local sources on mapbox.com to use them in composite sources.
