### PR TITLE
fixes #1057: persist OS X fullscreen state between launches

### DIFF
--- a/index-shell.js
+++ b/index-shell.js
@@ -72,6 +72,13 @@ function makeWindow() {
         }
     });
     mainWindow.loadUrl('file://' + path.join(__dirname, 'app', 'loading.html'));
+    // Restore OS X fullscreen state.
+    var cp = require("child_process");
+    if (cp.execSync("defaults read com.mapbox.mapbox-studio FullScreen") == 1) {
+        setTimeout(function(){
+            mainWindow.setFullScreen(true);
+        }, 100);
+    }
     // Emitted when the window is closed.
     mainWindow.on('closed', function() {
         // Dereference the window object, usually you would store windows
@@ -83,7 +90,17 @@ function makeWindow() {
     mainWindow.on('page-title-updated', function(e) {
         e.preventDefault();
     });
-
+    // Persist OS X fullscreen state.
+    function persistFullScreen() {
+        var cp = require("child_process");
+        cp.execSync("defaults write com.mapbox.mapbox-studio FullScreen -bool " + mainWindow.isFullScreen());
+    }
+    mainWindow.on('enter-full-screen', function(e) {
+        persistFullScreen();
+    });
+    mainWindow.on('leave-full-screen', function(e) {
+        persistFullScreen();
+    });
     createMenu();
     loadURL();
 }


### PR DESCRIPTION
Calls out to OS X's `/usr/bin/defaults` to work with regular application prefs on disk and updates the preference on window state toggle. Restores app state again on launch. 

/cc @camilleanne 
