### PR TITLE
Add tests ensuring no dupes to prevent tears

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "mapnik": "3.1.2",
     "mapnik-reference": "^6.0.4",
     "carto": "0.14.0",
-    "tilelive": "5.2.3",
+    "tilelive": "~5.6.1",
     "tilelive-bridge": "^1.2.1",
     "tilelive-vector": "^3.0.2",
     "mapbox-machine-styles": "2.3.0",
@@ -64,7 +64,7 @@
     "start": "./index.js",
     "preinstall": "node scripts/run.js scripts/vendor-node.sh",
     "postinstall": "npm dedupe node-pre-gyp",
-    "pretest": "npm ls --depth=Infinity > /dev/null && tape ./test/duplicate_module.pretest.js",
+    "pretest": "npm ls --depth=Infinity && tape ./test/duplicate_module.pretest.js",
     "test": "retire -n && tape test/*.test.js",
     "posttest": "node test/cleanup.js"
   }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "start": "./index.js",
     "preinstall": "node scripts/run.js scripts/vendor-node.sh",
     "postinstall": "npm dedupe node-pre-gyp",
+    "pretest": "npm ls --depth=Infinity > /dev/null && tape ./test/duplicate_module.pretest.js",
     "test": "retire -n && tape test/*.test.js",
     "posttest": "node test/cleanup.js"
   }

--- a/test/duplicate_module.pretest.js
+++ b/test/duplicate_module.pretest.js
@@ -21,7 +21,6 @@ var count_module = function (name, callback) {
     'srs',
     'tilelive',
     'mbtiles',
-    'tilelive-omnivore'
 ].forEach(function(mod) {
     tape.test('there should only be one ' + mod + ' module, otherwise you are asking for pwnage', function (t) {
         count_module(mod, function (err, count) {

--- a/test/duplicate_module.pretest.js
+++ b/test/duplicate_module.pretest.js
@@ -1,0 +1,34 @@
+var tape = require('tape');
+var exec = require('child_process').exec;
+
+var count_module = function (name, callback) {
+    var cmd = 'npm ls ' + name;
+    exec(cmd,
+        function (error, stdout, stderr) {
+            var pattern = new RegExp(name + '@', 'g');
+            var match = stdout.match(pattern);
+            if (!match) {
+                return callback(null, 0);
+            }
+            return callback(null, match.length);
+        });
+};
+
+[
+    'mapnik',
+    'sqlite3',
+    'gdal',
+    'srs',
+    'tilelive',
+    'mbtiles',
+    'tilelive-omnivore'
+].forEach(function(mod) {
+    tape.test('there should only be one ' + mod + ' module, otherwise you are asking for pwnage', function (t) {
+        count_module(mod, function (err, count) {
+            if (err) throw err;
+            t.notEqual(count, 0);
+            t.equal(count, 1);
+            t.end();
+        });
+    });
+});


### PR DESCRIPTION
- Adds duplicate module test.
- Upgrades tilelive to prevent duplicate installs

Note: I am seeing duplicate node-mapnik locally on OS X, but oddly not on travis/appveyor it appears.
