### PR TITLE
Report gzip content-encoding for vector.pbf response

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -208,7 +208,7 @@ function tile(req, res, next) {
 
         headers['cache-control'] = 'max-age=3600';
         if (req.params.format === 'vector.pbf') {
-            headers['content-encoding'] = 'deflate';
+            headers['Content-Encoding'] = 'gzip';
         }
         res.set(headers);
         return res.send(data);


### PR DESCRIPTION
This looks like a holdover from pre-gzip days.

@yhahn - can you give me a tip for where best to add a test for this? I've looked around middleware.test.js, source.test.js, and test-client.js but its opaque to me where the right place would be to query a source via url and assert on its content-encoding.
