### PR TITLE
Set cors headers for vtiles

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -206,6 +206,8 @@ function tile(req, res, next) {
             }, {});
         }
 
+        headers['Access-Control-Allow-Methods'] = 'GET';
+        headers['Access-Control-Allow-Origin'] = '*';
         headers['cache-control'] = 'max-age=3600';
         if (req.params.format === 'vector.pbf') {
             headers['content-encoding'] = 'deflate';


### PR DESCRIPTION
Companion to #1215.

This is intended to allow testing vtiles produced by Studio locally against mapbox-gl-js styles like:

``` js
{
  "sources": {
    "sourcename": {
      "type": "vector",
      "maxzoom": 14,
      "tiles": ["http://localhost:3001/source/{z}/{x}/{y}.vector.pbf?id=tmsource:///path/to/sourcename.tm2source"]
     }
  }
  [ .. snip ... ]
}}
```
