### PR TITLE
studio always opens on new project

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -74,21 +74,6 @@ middleware.examples = function(req, res, next) {
     });
 };
 
-middleware.latest = function(req, res, next) {
-    middleware.history(req, res, function(err) {
-        if (err) return next(err);
-        var history = tm.history();
-        for (var i = (history.length - 1); i > 0; i--) {
-            if (history[i].indexOf('tmstyle://') === 0 ||
-                history[i].indexOf('tmsource://') === 0) {
-                req.latest = history[i];
-                return next();
-            }
-        }
-        next();
-    });
-};
-
 middleware.newStyle = function(req, res, next) {
     // Let source for new styles be specified via querystring.
     if (req.query && req.query.remote) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -503,14 +503,8 @@ app.get('/new/source', middleware.exporting, middleware.newSource, function(req,
     res.redirect('/source?id=' + req.source.data.id);
 });
 
-app.get('/', middleware.latest, function(req, res, next) {
-    if (req.latest && req.latest.indexOf('tmstyle:') === 0) {
-        res.redirect('/style?id=' + req.latest);
-    } else if (req.latest && req.latest.indexOf('tmsource:') === 0) {
-        res.redirect('/source?id=' + req.latest);
-    } else {
-        res.redirect('/new/style');
-    }
+app.get('/', middleware.newStyle, function(req, res, next) {
+    res.redirect('/style?id=' + req.style.data.id);
 });
 
 app.get('/history.json', middleware.userTilesets, middleware.history, function(req, res, next) {

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -354,15 +354,6 @@ test('userTilesets: adds history entries for tilesets', function(t) {
     });
 });
 
-test('latest: finds latest local project entry', function(t) {
-    var req = {};
-    middleware.latest(req, {}, function(err) {
-        t.ifError(err);
-        t.equal(req.latest, sourceId, 'finds latest source');
-        t.end();
-    });
-});
-
 test('config: bad url', function(t) {
     var res = {};
     res.redirect = function(qs){


### PR DESCRIPTION
Improve stability by starting on a new style project rather than automatically loading latest project.
