### PR TITLE
Print spinner

### DIFF
--- a/app/atom.js
+++ b/app/atom.js
@@ -11,6 +11,7 @@ $(document).ready(function() {
     var http = require('http');
     var url = require('url');
     var fs = require('fs');
+    var path = require('path');
     var dialog = remote.require('dialog');
 
     $('body').on('click', 'a', function(ev) {
@@ -33,25 +34,29 @@ $(document).ready(function() {
         var typeExtension = (uri.pathname || '').split('.').pop().toLowerCase();
         var typeLabel = fileTypes[typeExtension];
         if (typeLabel) {
-            var filePath = dialog.showSaveDialog({
+            // HOME is undefined on windows
+            if (process.platform === 'win32') process.env.HOME = process.env.USERPROFILE;
+            var defaultPath = path.join(process.env.HOME,'Untitled ' + typeLabel + '.' + typeExtension);
+            dialog.showSaveDialog({
                 title: 'Save ' + typeLabel,
-                defaultPath: '~/Untitled ' + typeLabel + '.' + typeExtension,
+                defaultPath: defaultPath,
                 filters: [{ name: typeExtension.toUpperCase(), extensions: [typeExtension]}]
-            });
-            if (filePath) {
-                window.Modal.show('atomexporting');
-                uri.method = 'GET';
-                var writeStream = fs.createWriteStream(filePath);
-                var req = http.request(uri, function(res) {
-                    if (res.statusCode !== 200) return;
-                    res.pipe(writeStream);
-                    writeStream.on('finish', function() {
-                        window.Modal.close();
+            }, function(filePath){
+                if (filePath) {
+                    window.Modal.show('atomexporting');
+                    uri.method = 'GET';
+                    var writeStream = fs.createWriteStream(filePath);
+                    var req = http.request(uri, function(res) {
+                        if (res.statusCode !== 200) return;
+                        res.pipe(writeStream);
+                        writeStream.on('finish', function() {
+                            window.Modal.close();
+                        });
                     });
-                });
-                req.end();
-            }
-            return false;
+                    req.end();
+                }
+                return false;
+            });
         }
         // Passthrough everything else.
     });

--- a/app/atom.js
+++ b/app/atom.js
@@ -11,6 +11,7 @@ $(document).ready(function() {
     var http = require('http');
     var url = require('url');
     var fs = require('fs');
+    var dialog = remote.require('dialog');
 
     $('body').on('click', 'a', function(ev) {
         var uri = url.parse(ev.currentTarget.href);
@@ -32,7 +33,7 @@ $(document).ready(function() {
         var typeExtension = (uri.pathname || '').split('.').pop().toLowerCase();
         var typeLabel = fileTypes[typeExtension];
         if (typeLabel) {
-            var filePath = remote.require('dialog').showSaveDialog({
+            var filePath = dialog.showSaveDialog({
                 title: 'Save ' + typeLabel,
                 defaultPath: '~/Untitled ' + typeLabel + '.' + typeExtension,
                 filters: [{ name: typeExtension.toUpperCase(), extensions: [typeExtension]}]


### PR DESCRIPTION
There's a bug in atom-shell where if the savedialog is closed by the 'save' button before it loads, the default path concatenation is incorrect and it returns a bad filepath (e.g. `/Users/camille/Desktop/~/Image.png` when it should be `/Users/camille/Desktop/Image.png`). Ticket in atom-shell: https://github.com/atom/atom-shell/issues/1212.

This should work around that until there is a fix.

to do:
- [x] package and test on mac
- [x] package and test on windows

cc @amyleew @springmeyer 
