### PR TITLE
Auto-generate listing of downloads

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ Travis bundles Mapbox Studio with the [atom-shell](https://github.com/atom/atom-
 To package:
 
 1. **Push a commit with `[publish GITSHA]` as the message.** `GITSHA` should be a commit hash, branch name, or tag that can be used with `git checkout`. *Note: the packaging process itself will use the code in the repo as of GITSHA -- in other words, your GITSHA must be able to package itself.*
-2. **Check travis logs for success.** When complete downloads will be available at:
+2. **Watch travis for a for success.** When complete downloads will be available at <https://mapbox.s3.amazonaws.com/mapbox-studio/index.html> in the format of:
 
         https://mapbox.s3.amazonaws.com/mapbox-studio/mapbox-studio-linux-x64-{GITSHA}.zip
         https://mapbox.s3.amazonaws.com/mapbox-studio/mapbox-studio-darwin-x64-{GITSHA}.zip

--- a/scripts/build-travis.sh
+++ b/scripts/build-travis.sh
@@ -16,6 +16,9 @@ if [ $PLATFORM == "linux" ] && [ -n "$GITSHA" ]; then
     ./scripts/build-atom.sh "$GITSHA" linux
     ./scripts/build-atom.sh "$GITSHA" win32 x64
     ./scripts/build-atom.sh "$GITSHA" win32 ia32
+    aws s3 ls s3://mapbox/mapbox-studio/ > listing.txt
+    ./scripts/generate-s3-listing.py < listing.txt > index.html
+    aws s3 cp --acl=public-read index.html s3://mapbox/mapbox-studio/index.html
 elif [ $PLATFORM == "darwin" ] && [ -n "$GITSHA" ]; then
     echo "Publishing $GITSHA"
     brew install python

--- a/scripts/generate-s3-listing.py
+++ b/scripts/generate-s3-listing.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+import fileinput
+
+base_url = 'https://mapbox.s3.amazonaws.com/mapbox-studio'
+
+html_start = '''
+<html>
+<head><title>Mapbox Studio downloads</title></head>
+<body bgcolor="white">
+<h1>Mapbox Studio downloads</h1><hr><pre>
+'''
+
+html_end = '''
+</pre><hr></body>
+</html>
+'''
+
+line_template =  '%(date)s %(time)s  %(size)s  <a href="%(name)s">%(name)s</a>'
+
+print html_start
+
+downloads = {}
+
+for line in fileinput.input():
+    stripped = line.strip()
+    if 'mapbox-studio-' in stripped:
+        parts = stripped.split(' ')
+        date = parts[0]
+        time = parts[1]
+        size = '%s MB' % (int(parts[3])/1000000)
+        name = parts[4]
+        downloads[date+name] = line_template % (locals())
+
+sorted_by_date = sorted(downloads, key=lambda key: downloads[key])
+
+for dl in sorted_by_date: print downloads[dl]
+
+print html_end

--- a/scripts/generate-s3-listing.py
+++ b/scripts/generate-s3-listing.py
@@ -31,7 +31,7 @@ for line in fileinput.input():
         name = parts[4]
         downloads[date+name] = line_template % (locals())
 
-sorted_by_date = sorted(downloads, key=lambda key: downloads[key])
+sorted_by_date = sorted(downloads, key=lambda key: downloads[key], reverse=True)
 
 for dl in sorted_by_date: print downloads[dl]
 


### PR DESCRIPTION
This is to speed up grabbing the link when a test build is ready.

The page at https://mapbox.s3.amazonaws.com/mapbox-studio/index.html gets auto-updated whenever you push with a commit message like `-m [publish gitsha]`.

/cc @amyleew @camilleanne @samanpwbb @willwhite @bsudekum @yhahn @BergWerkGIS 
