### PR TITLE
[WIP] Test server http

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -47,7 +47,6 @@ var app = express();
 app.use(passport.initialize());
 app.use('/authorize', middleware.examples);
 app.use('/authorize', function(req, res) {
-    var latest = req.latest && (req.history.style[req.latest] || req.history.source[req.latest]);
     res.send(tm.templates.oauth({
         nocache: nocache,
         user: tm.db.get('user'),

--- a/test/http-server-app.test.js
+++ b/test/http-server-app.test.js
@@ -3,13 +3,16 @@ var spawn = require('child_process').spawn;
 var path = require('path');
 var assert = require('assert');
 var http = require('http');
+var fs = require('fs');
 
 test('server', function(t) {
     var mbstudio = spawn(path.join(__dirname,'../index.js'), [], {});
     mbstudio.stdout.on('data', function (data) {
-      t.ok(data.toString().indexOf('Mapbox Studio @ http://localhost:3000') > -1);
+      t.ok(data.toString().indexOf('Mapbox Studio @ http://localhost:3000') > -1,'server started on port');
       var url = 'http://localhost:3000/style/14/8716/8015{format}?id=tmpstyle://'
-      url += path.resolve(path.join(__dirname,'../node_modules/mapbox-machine-styles/node_modules/mapbox-studio-streets'));
+      var style_path = path.resolve(path.join(__dirname,'../node_modules/mapbox-machine-styles/node_modules/mapbox-studio-streets'));
+      t.ok(fs.existsSync(style_path),'test style exists');
+      url += style_path;
       t.test('fetches @2x.png', function(st) {
           var png_url = url.replace('{format}','@2x.png');
           http.get(png_url,function(res) {

--- a/test/http-server-app.test.js
+++ b/test/http-server-app.test.js
@@ -1,0 +1,59 @@
+var test = require('tape');
+var spawn = require('child_process').spawn;
+var path = require('path');
+var assert = require('assert');
+var http = require('http');
+
+test('server', function(t) {
+    var mbstudio = spawn(path.join(__dirname,'../index.js'), [], {});
+    mbstudio.stdout.on('data', function (data) {
+      t.ok(data.toString().indexOf('Mapbox Studio @ http://localhost:3000') > -1);
+      var url = 'http://localhost:3000/style/14/8716/8015{format}?id=tmpstyle://'
+      url += path.resolve(path.join(__dirname,'../node_modules/mapbox-machine-styles/node_modules/mapbox-studio-streets'));
+      t.test('fetches @2x.png', function(st) {
+          var png_url = url.replace('{format}','@2x.png');
+          http.get(png_url,function(res) {
+            t.equal(res.statusCode,200);
+            var headers = res.headers;
+            t.equal(headers['content-type'],'image/png');
+            t.equal(headers['access-control-allow-origin'],'*');
+            t.equal(headers['cache-control'],'max-age=3600');
+            st.end();
+          });
+      });
+      t.test('fetches @1x.png', function(st) {
+          var png_url = url.replace('{format}','.png');
+          http.get(png_url,function(res) {
+            t.equal(res.statusCode,200);
+            var headers = res.headers;
+            t.equal(headers['content-type'],'image/png');
+            t.equal(headers['access-control-allow-origin'],'*');
+            t.equal(headers['cache-control'],'max-age=3600');
+            st.end();
+          });
+      });
+      t.test('fetches vector.pbf', function(st) {
+          var png_url = url.replace('{format}','.vector.pbf');
+          http.get(png_url,function(res) {
+            t.equal(res.statusCode,200);
+            var headers = res.headers;
+            t.equal(headers['content-type'],'application/x-protobuf');
+            t.equal(headers['access-control-allow-origin'],'*');
+            t.equal(headers['cache-control'],'max-age=3600');
+            st.end();
+          });
+      });
+      t.test('shuts down server', function(st) {
+          mbstudio.kill();
+      });
+    });
+
+    mbstudio.stderr.on('data', function (data) {
+      t.fail("should not have got stderr: " + data);
+    });
+
+    mbstudio.on('close', function (code) {
+      t.equal(code,143);
+      t.end();
+    });
+ });


### PR DESCRIPTION
Start testing:
- startup of the server
- http response for basic  tile requests

This is working locally on OS X but failing for some unknown reason on travis. Will provide coverage for #1215 and #1216 once merged.
