### PR TITLE
changes View Data URL from /data to /uploads

### DIFF
--- a/templates/export.html
+++ b/templates/export.html
@@ -34,7 +34,7 @@
       <a href='/source?id=<%=source.id%>' class='button submit icon x task js-cancel'> Cancel export</a>
       <div class='stat col8 margin2 pad1'>
         <% if (job.type === 'upload') { %>
-        <a href='https://www.mapbox.com/data/' target='_blank' class='col12 short button icon stat cloud'>View data</a>
+        <a href='https://www.mapbox.com/uploads/?source=data' target='_blank' class='col12 short button icon stat cloud'>View data</a>
         <% } else if (job.type === 'export') { %>
         <a href='/source.mbtiles?id=<%= job.id %>' class='col12 short button icon folder stat'>Download</a>
         <% } %>


### PR DESCRIPTION
Currently linking to /data means that if a source is processing it looks like the upload was unsuccessful (since the new source isn't listed). Linking to the uploads will show that the Data is either processing or uploading, which is a better stepping stone 

![screen shot 2015-03-09 at 11 58 03 am](https://cloud.githubusercontent.com/assets/865298/6562130/a4c6c222-c653-11e4-8f2f-04cb1a41f041.png)
