### PR TITLE
Fix broken exports on windows

### DIFF
--- a/app/atom.js
+++ b/app/atom.js
@@ -57,6 +57,7 @@ $(document).ready(function() {
                 }
                 return false;
             });
+            return false;
         }
         // Passthrough everything else.
     });

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,5 +1,6 @@
 var _ = require('underscore');
 var path = require('path');
+var url = require('url');
 var request = require('request');
 var source = require('../lib/source');
 var style = require('../lib/style');
@@ -17,11 +18,11 @@ middleware.userTilesets = function(req, res, next) {
         return next(err);
     }
     req.accesstoken = oauth.accesstoken;
-    if (tm.oauth().isMapboxAPI) var url = tm.apiConfig('MapboxAPIAuth')+'/api/Map?account='+oauth.account+'&_type=tileset&private=true&access_token='+oauth.accesstoken;
-    else var url = tm.apiConfig('MapboxAPITile')+'/atlas/maps';
-    request(url, function(err, resp, body) {
+    if (tm.oauth().isMapboxAPI) var uri = tm.apiConfig('MapboxAPIAuth')+'/api/Map?account='+oauth.account+'&_type=tileset&private=true&access_token='+oauth.accesstoken;
+    else var uri = tm.apiConfig('MapboxAPITile')+'/atlas/maps';
+    request(uri, function(err, resp, body) {
         if (err) return next(err);
-        if (resp.statusCode !== 200) return next(new Error(resp.statusCode + ' GET ' + url));
+        if (resp.statusCode !== 200) return next(new Error(resp.statusCode + ' GET ' + uri));
         var tilesets;
         try { tilesets = JSON.parse(body); } catch(err) { next(err); }
         tilesets.forEach(function(t) {
@@ -81,7 +82,7 @@ middleware.newStyle = function(req, res, next) {
         if (!(/^(https?:\/\/)|(mapbox:\/\/)/).test(id)) {
             id = 'mapbox:///' + id;
         }
-        req.query.source = id;
+        req.query.source = url.format(id);
     }
     if (req.query && req.query.source) {
         style.clear(style.tmpid());
@@ -102,6 +103,7 @@ middleware.newStyle = function(req, res, next) {
         });
     } else {
         var id = (req.query && req.query.id) || style.tmpid();
+        id = url.format(id);
         style.clear(id);
         style(id, function(err, s) {
             if (err) return next(err);
@@ -134,7 +136,7 @@ middleware.writeStyle = function(req, res, next) {
 }
 
 middleware.loadStyle = function(req, res, next) {
-    style(req.query.id, function(err, s) {
+    style(url.format(req.query.id), function(err, s) {
         if (err) return next(err);
         if (!style.tmpid(s.data.id)) tm.history(s.data.id);
         req.style = s;
@@ -164,7 +166,7 @@ middleware.writeSource = function(req, res, next) {
 };
 
 middleware.loadSource = function(req, res, next) {
-    source(req.query.id, function(err, s) {
+    source(url.format(req.query.id), function(err, s) {
         if (err) return next(err);
         if (!source.tmpid(s.data.id)) tm.history(s.data.id);
         req.source = s;

--- a/lib/source.js
+++ b/lib/source.js
@@ -403,6 +403,7 @@ source.normalize = function(data) {
 // Light read of style info.
 source.info = function(id, callback) {
     var uri = tm.parse(id);
+    id = url.format(uri);
 
     if (!protocolIsValid(uri.protocol))
         return callback(new Error('Invalid source protocol'));


### PR DESCRIPTION
Due to wonky normalization of wonky windows paths, source exports were trying to download a cached file that didn't exist:

![screen shot 2015-03-10 at 11 38 49 am](https://cloud.githubusercontent.com/assets/3952537/6580329/43ed82c8-c726-11e4-95a6-6fb37445b019.png)
cc @mtirwin @springmeyer 
