### PR TITLE
Windows enable shelllog

### DIFF
--- a/index-shell.js
+++ b/index-shell.js
@@ -27,12 +27,9 @@ process.on('exit', function(code) {
 
 
 function exit() {
-    console.log('exit()');
     if (server){ server.kill() };
-    //if (atom) atom.quit(); //https://github.com/atom/atom-shell/blob/master/docs/api/app.md#app
-    console.log('listeners', atom.listeners('window-all-closed').length)
+    //atom.quit(); //is the way to do it: https://github.com/atom/atom-shell/blob/master/docs/api/app.md#app
     if (atom.listeners('window-all-closed').length == 1){ atom.quit(); }
-    //process.exit();
 };
 
 
@@ -41,7 +38,6 @@ var shellLog = path.join(process.env.HOME, '.mapbox-studio', 'shell.log');
 log(shellLog, 10e6, shellsetup);
 
 function shellsetup(err){
-    console.log('shellsetup() ENTER');
 
     // Start the server child process.
     server = spawn(node, [script, '--shell=true'])
@@ -53,10 +49,7 @@ function shellsetup(err){
         process.stdout.write('server process has no pid\n');
     } else {
         process.stdout.write('server process pid: ' + server.pid + '\n');
-        console.log('after spawn before server.on.exit');
         server.stdout.once('data', function(data) {
-            console.log('server.stdout.once');
-            /*
             var matches = data.toString().match(/Mapbox Studio @ http:\/\/localhost:([0-9]+)\//);
             if (!matches) {
                 console.warn('Server port not found');
@@ -64,21 +57,15 @@ function shellsetup(err){
             }
             serverPort = matches[1];
             logger.debug('Mapbox Studio @ http://localhost:'+serverPort+'/');
-            */
-            serverPort = 3000;
-            console.log('serverPort', serverPort);
             loadURL();
         });
 
         // Report crashes to our server.
         require('crash-reporter').start();
     }
-
-    console.log('shellsetup() EXIT');
 };
 
 function makeWindow() {
-    console.log('makeWindow()');
     // Create the browser window.
     mainWindow = new BrowserWindow({
         width: 960,
@@ -94,7 +81,6 @@ function makeWindow() {
         }
     });
     mainWindow.loadUrl('file://' + path.join(__dirname, 'app', 'loading.html'));
-    mainWindow.openDevTools();
     // Restore OS X fullscreen state.
     var cp = require("child_process");
     if (cp.execSync("which defaults >/dev/null && defaults read com.mapbox.mapbox-studio FullScreen 2>/dev/null || echo 0") == 1) {
@@ -129,7 +115,6 @@ function makeWindow() {
 }
 
 function loadURL() {
-    console.log('loadURL()', !mainWindow, !serverPort);
     if (!mainWindow) return;
     if (!serverPort) return;
     versionCheck({

--- a/index-shell.js
+++ b/index-shell.js
@@ -15,13 +15,12 @@ var mainWindow = null;
 if (process.platform === 'win32') {
     // HOME is undefined on windows
     process.env.HOME = process.env.USERPROFILE;
-    // skill shell.log setup
-    shellsetup();
-} else {
-    var shellLog = path.join(process.env.HOME, '.mapbox-studio', 'shell.log');
-    // set up shell.log and log rotation
-    log(shellLog, 10e6, shellsetup);
 }
+
+var shellLog = path.join(process.env.HOME, '.mapbox-studio', 'shell.log');
+// set up shell.log and log rotation
+log(shellLog, 10e6, shellsetup);
+
 
 function shellsetup(err){
     process.on('exit', function(code) {
@@ -32,6 +31,7 @@ function shellsetup(err){
     var server = spawn(node, [script, '--shell=true']);
     server.on('exit', process.exit);
     server.stdout.once('data', function(data) {
+        /*
         var matches = data.toString().match(/Mapbox Studio @ http:\/\/localhost:([0-9]+)\//);
         if (!matches) {
             console.warn('Server port not found');
@@ -39,6 +39,8 @@ function shellsetup(err){
         }
         serverPort = matches[1];
         logger.debug('Mapbox Studio @ http://localhost:'+serverPort+'/');
+        */
+        serverPort = 3000;
         loadURL();
     });
 

--- a/lib/log.js
+++ b/lib/log.js
@@ -6,8 +6,7 @@ var rotate = require('log-rotate');
 module.exports = function(filepath, maxsize, callback) {
     if (!filepath) return callback();
 
-    return callback();
-
+/*
     fs.stat(filepath, function(err, stat) {
         if (err && err.code !== 'ENOENT') return callback(err);
         if (stat && !stat.isFile()) return callback(new Error(filepath + ' is not a file'));
@@ -20,6 +19,14 @@ module.exports = function(filepath, maxsize, callback) {
             setup(stat && stat.size || 0);
         }
     });
+*/
+
+    fs.exists(filepath, function(exists){
+        //console.log('fs.exists');
+        return callback();
+    });
+
+//    return callback();
 
     function setup(offset) {
         var logstream = fs.createWriteStream(filepath, {

--- a/lib/log.js
+++ b/lib/log.js
@@ -6,6 +6,8 @@ var rotate = require('log-rotate');
 module.exports = function(filepath, maxsize, callback) {
     if (!filepath) return callback();
 
+    return callback();
+
     fs.stat(filepath, function(err, stat) {
         if (err && err.code !== 'ENOENT') return callback(err);
         if (stat && !stat.isFile()) return callback(new Error(filepath + ' is not a file'));

--- a/lib/log.js
+++ b/lib/log.js
@@ -6,7 +6,6 @@ var rotate = require('log-rotate');
 module.exports = function(filepath, maxsize, callback) {
     if (!filepath) return callback();
 
-/*
     fs.stat(filepath, function(err, stat) {
         if (err && err.code !== 'ENOENT') return callback(err);
         if (stat && !stat.isFile()) return callback(new Error(filepath + ' is not a file'));
@@ -19,14 +18,7 @@ module.exports = function(filepath, maxsize, callback) {
             setup(stat && stat.size || 0);
         }
     });
-*/
 
-    fs.exists(filepath, function(exists){
-        //console.log('fs.exists');
-        return callback();
-    });
-
-//    return callback();
 
     function setup(offset) {
         var logstream = fs.createWriteStream(filepath, {


### PR DESCRIPTION
@springmeyer please review.
Turns out, no `blockingio` issues or anything similiar, just the order how things are called changed when using shelllog.
Probably because everything is bit slower on Windows.
I moved things around a bit and now it works.

Async is hard :smirk: 

BTW: We don't get an exit code anymore, because I switch from `process.exit()` to `atom.quit()`, which seems, [according to the docs](https://github.com/atom/atom-shell/blob/master/docs/api/app.md#app) the way to do it.
Because of that `code===undefined` in `process.on('exit', function(code)`.
