### PR TITLE
Space odyssey

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
 #  - psql -c "CREATE EXTENSION postgis" template_postgis
 
 before_install:
+- echo $TRAVIS_BUILD_DIR && exit 1
 - git clone https://github.com/creationix/nvm.git ../.nvm && source ../.nvm/nvm.sh
 - nvm install $NODE_VERSION
 - nvm use $NODE_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,10 @@ env:
 #  - psql -c "CREATE EXTENSION postgis" template_postgis
 
 before_install:
-- echo $TRAVIS_BUILD_DIR && exit 1
+# move from mapbox-studio to "Mapbox Studio" to run tests with spacey paths
+- export TRAVIS_BUILD_DIR_OLD="$TRAVIS_BUILD_DIR"
+- export TRAVIS_BUILD_DIR="$(dirname $TRAVIS_BUILD_DIR)/Mapbox Studio"
+- cd $HOME && mv $TRAVIS_BUILD_DIR_OLD $TRAVIS_BUILD_DIR && cd $TRAVIS_BUILD_DIR
 - git clone https://github.com/creationix/nvm.git ../.nvm && source ../.nvm/nvm.sh
 - nvm install $NODE_VERSION
 - nvm use $NODE_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,6 @@ env:
 #  - psql -c "CREATE EXTENSION postgis" template_postgis
 
 before_install:
-# move from mapbox-studio to "Mapbox Studio" to run tests with spacey paths
-- export TRAVIS_BUILD_DIR_OLD="$TRAVIS_BUILD_DIR"
-- export TRAVIS_BUILD_DIR="$(dirname $TRAVIS_BUILD_DIR)/Mapbox Studio"
-- cd $HOME && mv "$TRAVIS_BUILD_DIR_OLD" "$TRAVIS_BUILD_DIR" && cd "$TRAVIS_BUILD_DIR"
 - git clone https://github.com/creationix/nvm.git ../.nvm && source ../.nvm/nvm.sh
 - nvm install $NODE_VERSION
 - nvm use $NODE_VERSION
@@ -42,7 +38,11 @@ install:
 - python test/check_shared_libs.py node_modules/
 
 before_script:
- - npm ls
+- npm ls
+# move from mapbox-studio to "Mapbox Studio" to run tests with spacey paths
+- export TRAVIS_BUILD_DIR_OLD="$TRAVIS_BUILD_DIR"
+- export TRAVIS_BUILD_DIR="$(dirname $TRAVIS_BUILD_DIR)/Mapbox Studio"
+- cd $HOME && mv "$TRAVIS_BUILD_DIR_OLD" "$TRAVIS_BUILD_DIR" && cd "$TRAVIS_BUILD_DIR"
 
 script:
  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,12 @@ install:
 
 before_script:
 - npm ls
+
 # move from mapbox-studio to "Mapbox Studio" to run tests with spacey paths
 - export TRAVIS_BUILD_DIR_OLD="$TRAVIS_BUILD_DIR"
 - export TRAVIS_BUILD_DIR="$(dirname $TRAVIS_BUILD_DIR)/Mapbox Studio"
 - cd $HOME && mv "$TRAVIS_BUILD_DIR_OLD" "$TRAVIS_BUILD_DIR" && cd "$TRAVIS_BUILD_DIR"
+- export LD_PRELOAD="$(pwd)/usr/lib/x86_64-linux-gnu/libstdc++.so.6"
 
 script:
  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 # move from mapbox-studio to "Mapbox Studio" to run tests with spacey paths
 - export TRAVIS_BUILD_DIR_OLD="$TRAVIS_BUILD_DIR"
 - export TRAVIS_BUILD_DIR="$(dirname $TRAVIS_BUILD_DIR)/Mapbox Studio"
-- cd $HOME && mv $TRAVIS_BUILD_DIR_OLD $TRAVIS_BUILD_DIR && cd $TRAVIS_BUILD_DIR
+- cd $HOME && mv "$TRAVIS_BUILD_DIR_OLD" "$TRAVIS_BUILD_DIR" && cd "$TRAVIS_BUILD_DIR"
 - git clone https://github.com/creationix/nvm.git ../.nvm && source ../.nvm/nvm.sh
 - nvm install $NODE_VERSION
 - nvm use $NODE_VERSION


### PR DESCRIPTION
Travis is stuck trying to test this branch (https://travis-ci.org/mapbox/mapbox-studio/jobs/55062467) so I'm queuing up this pull so we can discuss testing locally and how to fix the test failures.

Locally I've renamed my git clone to `mb studio` and running the test I see:

```
not ok 187 source.info adds id key
  ---
    operator: equal
    expected:
      'tmsource:///Users/dane/projects/mb studio/test/fixtures-localsource'
    actual:
      'tmsource:///Users/dane/projects/mb%20studio/test/fixtures-localsource'
    at: /Users/dane/projects/mb studio/test/source.test.js:374:11
  ...
ok 188 style info adds _tmp=false
not ok 189 should be equivalent
  ---
    operator: deepEqual
    expected:
      { Layer: [ { Datasource: { file: '10m-900913-bounding-box.shp', type: 'shape' }, description: '', id: 'solid', name: 'solid', properties: { 'buffer-size': 0 }, srs: '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over' }, { Datasource: { file: '10m_lakes_historic.shp', type: 'shape' }, description: '', id: 'box', name: 'box', properties: { 'buffer-size': 0 }, srs: '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over' } ], _tmp: false, attribution: 'John Doe 2013.', id: 'tmsource://[BASEPATH]', maxzoom: 6, minzoom: 0, name: 'Test source' }
    actual:
      { Layer: [ { Datasource: { file: '10m-900913-bounding-box.shp', type: 'shape' }, description: '', id: 'solid', name: 'solid', properties: { 'buffer-size': 0 }, srs: '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over' }, { Datasource: { file: '10m_lakes_historic.shp', type: 'shape' }, description: '', id: 'box', name: 'box', properties: { 'buffer-size': 0 }, srs: '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over' } ], _tmp: false, attribution: 'John Doe 2013.', id: 'tmsource:///Users/dane/projects/mb%20studio/test/fixtures-localsource', maxzoom: 6, minzoom: 0, name: 'Test source' }
    at: /Users/dane/projects/mb studio/test/source.test.js:384:11
  ...
# source.info: reads source YML (tmp)
ok 190 null
not ok 191 source.info adds id key
  ---
    operator: equal
    expected:
      'tmpsource:///Users/dane/projects/mb studio/test/fixtures-localsource'
    actual:
      'tmpsource:///Users/dane/projects/mb%20studio/test/fixtures-localsource'
    at: /Users/dane/projects/mb studio/test/source.test.js:393:11
  ...
not ok 192 should be equivalent
  ---
    operator: deepEqual
    expected:
      { Layer: [ { Datasource: { file: '10m-900913-bounding-box.shp', type: 'shape' }, description: '', id: 'solid', name: 'solid', properties: { 'buffer-size': 0 }, srs: '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over' }, { Datasource: { file: '10m_lakes_historic.shp', type: 'shape' }, description: '', id: 'box', name: 'box', properties: { 'buffer-size': 0 }, srs: '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over' } ], _tmp: 'tmpsource://[BASEPATH]', attribution: 'John Doe 2013.', id: 'tmpsource://[BASEPATH]', maxzoom: 6, minzoom: 0, name: 'Test source' }
    actual:
      { Layer: [ { Datasource: { file: '10m-900913-bounding-box.shp', type: 'shape' }, description: '', id: 'solid', name: 'solid', properties: { 'buffer-size': 0 }, srs: '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over' }, { Datasource: { file: '10m_lakes_historic.shp', type: 'shape' }, description: '', id: 'box', name: 'box', properties: { 'buffer-size': 0 }, srs: '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over' } ], _tmp: 'tmpsource:///Users/dane/projects/mb%20studio/test/fixtures-localsource', attribution: 'John Doe 2013.', id: 'tmpsource:///Users/dane/projects/mb%20studio/test/fixtures-localsource', maxzoom: 6, minzoom: 0, name: 'Test source' }
    at: /Users/dane/projects/mb studio/test/source.test.js:403:11
  ...
# source export: setup
# source.mbtilesExport: exports mbtiles file
ok 193 null
ok 194 export does not exist yet
ok 195 sets task.id
ok 196 sets task.progress

/Users/dane/projects/mb studio/node_modules/tape/index.js:75
        throw err
              ^
TypeError: Cannot read property 'minX' of undefined
    at /Users/dane/projects/mb studio/node_modules/tilelive/lib/stream-pyramid.js:77:45
    at CachingSource.<anonymous> (/Users/dane/projects/mb studio/node_modules/tilelive-bridge/index.js:255:16)
    at dispense (/Users/dane/projects/mb studio/node_modules/tilelive-bridge/node_modules/mapnik-pool/node_modules/generic-pool/lib/generic-pool.js:250:16)
    at Object.me.acquire (/Users/dane/projects/mb studio/node_modules/tilelive-bridge/node_modules/mapnik-pool/node_modules/generic-pool/lib/generic-pool.js:319:5)
    at CachingSource.Bridge.getInfo (/Users/dane/projects/mb studio/node_modules/tilelive-bridge/index.js:204:15)
    at Pyramid._params (/Users/dane/projects/mb studio/node_modules/tilelive/lib/stream-pyramid.js:47:19)
    at Pyramid._read (/Users/dane/projects/mb studio/node_modules/tilelive/lib/stream-pyramid.js:89:39)
    at Pyramid.Readable.read (_stream_readable.js:341:10)
    at Pyramid.Readable.on (_stream_readable.js:720:14)
    at Pyramid.Readable.pipe (_stream_readable.js:575:10)
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0

```
