### PR TITLE
Delay setView when adding layers to source mode

### DIFF
--- a/app/source.js
+++ b/app/source.js
@@ -366,7 +366,9 @@ window.Source = function(templates, cwd, tm, source, revlayers, examples, isMapb
             // show new layer
             var center = metadata.center;
             var zoom = Math.max(metadata.minzoom, view.model.get('minzoom'));
-            map.setView([center[1], center[0]], zoom);
+            setTimeout(function() {
+                map.setView([center[1], center[0]], zoom);
+            }, 500);
 
             //open proper modal, depending on if there are multiple layers
             if (layersArray.length > 1) {


### PR DESCRIPTION
refs #1254 

I went digging deep into the bowels of Leaflet to see if I could figure out why these calls to `setView` did not end up actually changing the map's center / zoom, but I couldn't come up with much. Delaying the `setView` calls by 500ms solved the problem in the test data that @samanpwbb provided in the ticket above.

@GretaCB: can you confirm / deny that the upcoming https://github.com/mapbox/mapbox-studio/pull/1199 also fixes the problem? If so, and we're going to land it soon, we probably don't want to merge this PR. I'd also be curious if @Brideau sees similar fixes on either of these branches with your problematic datasets?

If we **do** want to merge this I'll work on a testcase for it.
