### PR TITLE
disable animation on setView, fix #1254

### DIFF
--- a/app/source.js
+++ b/app/source.js
@@ -366,7 +366,7 @@ window.Source = function(templates, cwd, tm, source, revlayers, examples, isMapb
             // show new layer
             var center = metadata.center;
             var zoom = Math.max(metadata.minzoom, view.model.get('minzoom'));
-            map.setView([center[1], center[0]], zoom);
+            map.setView([center[1], center[0]], zoom, {'animate': false});
 
             //open proper modal, depending on if there are multiple layers
             if (layersArray.length > 1) {
@@ -569,7 +569,7 @@ window.Source = function(templates, cwd, tm, source, revlayers, examples, isMapb
     Editor.prototype.refresh = function(ev) {
         if (!map) {
             map = L.mapbox.map('map');
-            map.setView([this.model.get('center')[1], this.model.get('center')[0]], this.model.get('center')[2]);
+            map.setView([this.model.get('center')[1], this.model.get('center')[0]], this.model.get('center')[2], {'animate': false});
             this.map = map;
 
             map.on('zoomend', function() {
@@ -686,7 +686,7 @@ window.Source = function(templates, cwd, tm, source, revlayers, examples, isMapb
                 $('#full').removeClass('loading');
                 var center = metadata.center;
                 var zoom = Math.max(metadata.minzoom, view.model.get('minzoom'));
-                map.setView([center[1], center[0]], zoom);
+                map.setView([center[1], center[0]], zoom, {'animate': false});
             },
             error: function(jqXHR, textStatus, errorThrown) {
                 // Clear loading state

--- a/app/test/app.test.source.js
+++ b/app/test/app.test.source.js
@@ -482,8 +482,9 @@ for (var name in datatests) (function(name, info) {
             var newCenter = [
                 window.editor.map.getCenter().lat,
                 window.editor.map.getCenter().lng,
-                zoom
+                window.editor.map.getZoom()
             ];
+
             t.notDeepEqual(newCenter, initialCenter, 'map re-centers on new layer');
 
             t.equal($('.pane.target').length,1,'only current layer pane is targeted');

--- a/app/test/app.test.source.js
+++ b/app/test/app.test.source.js
@@ -350,10 +350,10 @@ var datatests = {
             'srs': '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs'
         }
     },
-    'geojson/DC_polygon.geo.json': {
-        filepath: '/geojson/DC_polygon.geo.json',
+    'geojson/places.geo.json': {
+        filepath: '/geojson/places.geo.json',
         expected: {
-            'Datasource-file': window.testParams.dataPath + '/geojson/DC_polygon.geo.json',
+            'Datasource-file': window.testParams.dataPath + '/geojson/places.geo.json',
             'Datasource-layer': 'OGRGeoJSON',
             'Datasource-type': 'ogr',
             'description': '',
@@ -362,10 +362,10 @@ var datatests = {
             'srs': '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs'
         }
     },
-    'geojson/places.geo.json': {
-        filepath: '/geojson/places.geo.json',
+    'geojson/DC_polygon.geo.json': {
+        filepath: '/geojson/DC_polygon.geo.json',
         expected: {
-            'Datasource-file': window.testParams.dataPath + '/geojson/places.geo.json',
+            'Datasource-file': window.testParams.dataPath + '/geojson/DC_polygon.geo.json',
             'Datasource-layer': 'OGRGeoJSON',
             'Datasource-type': 'ogr',
             'description': '',
@@ -461,6 +461,12 @@ for (var name in datatests) (function(name, info) {
         t.equal($('#addlayer input[name=Datasource-file]').get(0).validity.valid, true);
         $('#addlayer').submit();
 
+        var initialCenter = [
+            window.editor.map.getCenter().lat,
+            window.editor.map.getCenter().lng,
+            window.editor.map.getZoom()
+        ];
+
         onajax(afterOmnivore);
         onajax(afterUpdate);
         onajax(afterUpdate2);
@@ -472,6 +478,13 @@ for (var name in datatests) (function(name, info) {
 
         function afterUpdate() {
             t.ok($('#layers-' + info.expected.id).hasClass('target'),'current layer pane is targeted');
+
+            var newCenter = [
+                window.editor.map.getCenter().lat,
+                window.editor.map.getCenter().lng,
+                zoom
+            ];
+            t.notDeepEqual(newCenter, initialCenter, 'map re-centers on new layer');
 
             t.equal($('.pane.target').length,1,'only current layer pane is targeted');
 


### PR DESCRIPTION
Removes animation from map centering when new layers are added, as a work around to a suspected Leaflet bug in https://github.com/Leaflet/Leaflet/blob/v0.7.3/src/map/anim/Map.ZoomAnimation.js that was causing maps to stall when adding certain data layers, uncovered by @rclark. 

Replaces https://github.com/mapbox/mapbox-studio/pull/1269
