### PR TITLE
No-op on non-darwin platforms for OS X fullscreeney stuff

### DIFF
--- a/index-shell.js
+++ b/index-shell.js
@@ -73,12 +73,7 @@ function makeWindow() {
     });
     mainWindow.loadUrl('file://' + path.join(__dirname, 'app', 'loading.html'));
     // Restore OS X fullscreen state.
-    var cp = require("child_process");
-    if (cp.execSync("which defaults >/dev/null && defaults read com.mapbox.mapbox-studio FullScreen 2>/dev/null || echo 0") == 1) {
-        setTimeout(function(){
-            mainWindow.setFullScreen(true);
-        }, 100);
-    }
+    restoreFullScreen();
     // Emitted when the window is closed.
     mainWindow.on('closed', function() {
         // Dereference the window object, usually you would store windows
@@ -90,11 +85,6 @@ function makeWindow() {
     mainWindow.on('page-title-updated', function(e) {
         e.preventDefault();
     });
-    // Persist OS X fullscreen state.
-    function persistFullScreen() {
-        var cp = require("child_process");
-        cp.execSync("which defaults >/dev/null && defaults write com.mapbox.mapbox-studio FullScreen -bool " + mainWindow.isFullScreen());
-    }
     mainWindow.on('enter-full-screen', function(e) {
         persistFullScreen();
     });
@@ -103,6 +93,24 @@ function makeWindow() {
     });
     createMenu();
     loadURL();
+
+    // Restore OS X fullscreen state.
+    function restoreFullScreen() {
+        if (process.platform !== 'darwin') return;
+        var cp = require("child_process");
+        if (cp.execSync("which defaults >/dev/null && defaults read com.mapbox.mapbox-studio FullScreen 2>/dev/null || echo 0") == 1) {
+            setTimeout(function(){
+                mainWindow.setFullScreen(true);
+            }, 100);
+        }
+    }
+
+    // Persist OS X fullscreen state.
+    function persistFullScreen() {
+        if (process.platform !== 'darwin') return;
+        var cp = require("child_process");
+        cp.execSync("which defaults >/dev/null && defaults write com.mapbox.mapbox-studio FullScreen -bool " + mainWindow.isFullScreen());
+    }
 }
 
 function loadURL() {

--- a/index-shell.js
+++ b/index-shell.js
@@ -98,7 +98,7 @@ function makeWindow() {
     function restoreFullScreen() {
         if (process.platform !== 'darwin') return;
         var cp = require("child_process");
-        if (cp.execSync("which defaults >/dev/null && defaults read com.mapbox.mapbox-studio FullScreen 2>/dev/null || echo 0") == 1) {
+        if (cp.execSync("defaults read com.mapbox.mapbox-studio FullScreen 2>/dev/null || echo 0") == 1) {
             setTimeout(function(){
                 mainWindow.setFullScreen(true);
             }, 100);
@@ -109,7 +109,7 @@ function makeWindow() {
     function persistFullScreen() {
         if (process.platform !== 'darwin') return;
         var cp = require("child_process");
-        cp.execSync("which defaults >/dev/null && defaults write com.mapbox.mapbox-studio FullScreen -bool " + mainWindow.isFullScreen());
+        cp.execSync("defaults write com.mapbox.mapbox-studio FullScreen -bool " + mainWindow.isFullScreen());
     }
 }
 


### PR DESCRIPTION
Skips running of any fullscreen state checks when not on OS X. Ran into an issue on linux with this.

cc @incanus @camilleanne 
