### PR TITLE
Fix path normalization to work with HTTP URLs containing host names.

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -22,7 +22,12 @@ middleware.normalizePaths = function(req, res, next) {
     ['id','source'].forEach(function(key) {
         if (!req.body || !req.body[key]) return;
         var uri = tm.parse(req.body[key]);
-        req.body[key] = (uri.protocol ? uri.protocol + '//' : '') + uri.dirname;
+        // The object returned when the url library parses paths from Windows
+        // machines (e.g: file://c:\path) has the drive letter as the host
+        // field, so we need to exclude the host from the normalised path
+        // when we detect that it's a windows path.
+        var is_windows = (req.body[key].indexOf(':\\') >= 0);
+        req.body[key] = (uri.protocol ? uri.protocol + '//' : '') + (is_windows ? '' : uri.host) + uri.dirname;
     });
     next();
 };

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -17,7 +17,8 @@ middleware.normalizePaths = function(req, res, next) {
     ['id','source','style'].forEach(function(key) {
         if (!req.query[key]) return;
         var uri = tm.parse(req.query[key]);
-        req.query[key] = (uri.protocol ? uri.protocol + '//' : '') + uri.dirname;
+        var is_windows = (req.query[key].indexOf(':\\') >= 0);
+        req.query[key] = (uri.protocol ? uri.protocol + '//' : '') + (is_windows ? '' : uri.host) + uri.dirname;
     });
     ['id','source'].forEach(function(key) {
         if (!req.body || !req.body[key]) return;

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -18,7 +18,9 @@ middleware.normalizePaths = function(req, res, next) {
         if (!req.query[key]) return;
         var uri = tm.parse(req.query[key]);
         var is_windows = (req.query[key].indexOf(':\\') >= 0);
-        req.query[key] = (uri.protocol ? uri.protocol + '//' : '') + (is_windows ? '' : uri.host) + uri.dirname;
+        var protocol = uri.protocol ? uri.protocol + '//' : '';
+        var host = (is_windows || !uri.host) ? '' : uri.host;
+        req.query[key] = protocol + host + uri.dirname;
     });
     ['id','source'].forEach(function(key) {
         if (!req.body || !req.body[key]) return;
@@ -28,7 +30,9 @@ middleware.normalizePaths = function(req, res, next) {
         // field, so we need to exclude the host from the normalised path
         // when we detect that it's a windows path.
         var is_windows = (req.body[key].indexOf(':\\') >= 0);
-        req.body[key] = (uri.protocol ? uri.protocol + '//' : '') + (is_windows ? '' : uri.host) + uri.dirname;
+        var protocol = uri.protocol ? uri.protocol + '//' : '';
+        var host = (is_windows || !uri.host) ? '' : uri.host;
+        req.body[key] = protocol + host + uri.dirname;
     });
     next();
 };

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -96,6 +96,24 @@ test('normalizePaths', function(assert) {
         assert.deepEqual(req.body.source, 'tmsource://c:/path with/spaces/source.tm2source');
     });
 
+    req = {
+	// NOTE: these are empty for this test - we do not check their values
+	// but they are required to be present.
+	query: {
+	    id: '',
+	    style: '',
+	    source: ''
+	},
+	body: {
+	    id: '',
+	    source: 'http://localhost:31337/path/to/tile.json'
+	}
+    }
+    middleware.normalizePaths(req, {}, function(err) {
+	assert.ifError(err);
+	assert.deepEqual(req.body.source, 'http://localhost:31337/path/to/tile.json');
+    });
+
     assert.end();
 });
 


### PR DESCRIPTION
See #1288 for context. Basically, dropping the host name causes "Invalid URL" failures deeper inside tilelive, but it's slightly complicated by the way the "url" library parses Windows file paths as if the drive letter were the host name.
