### PR TITLE
JS Exception in server should be logged in app.log

### DIFF
--- a/index-server.js
+++ b/index-server.js
@@ -26,6 +26,12 @@ config.test = config.test || false;
 config.cwd = path.resolve(config.cwd || process.env.HOME);
 var logger = require('fastlog')('', 'debug', '<${timestamp}>');
 
+process.on('uncaughtException', function(err) {
+    logger.debug('Hit unexpected JS Error in server, please report this entire log to https://github.com/mapbox/mapbox-studio/issues');
+    if (err) logger.debug(err);
+    else logger.debug('no error reported');
+});
+
 var usage = function usage() {
   var str = [
       ''


### PR DESCRIPTION
I've found that currently if `throw error` happens in the server:
- nothing is logged
- the server exits
- then atom-shell client exits by responding to the server exit [here](https://github.com/mapbox/mapbox-studio/blob/mb-pages/index-shell.js#L33)

So a server crash basically silently and immediately brings the whole app down.

One step forward (and what this pull request is limited to) would be to at least log the cause of the crash to `app.log` so that users can help us know what happened and fix it. A server crash should never happen, but obviously if it does then we want to know the full stack trace to be able to fix it.

/cc @bsudekum can you ensure this same situation is logged in tilemill (I think it already is).

/cc @yhahn and @camilleanne for gut check

Next action before merging:
- [ ]  A test to simulate a server crash, and then confirm the stack trace shows up in the logs (no idea yet how to do this)

While I'm here thinking about this, a blue sky solution would be:
- the error is logged
- the server, upon exit (or somehow before) communicates the error to the shell
- the shell knows a fatal error was hit, catches it, and displays a modal for the user
- the user is 1) ask to report a bug, and 2) told that the error can be found later on in the logs at ~/.mapbox-studio/app.log
- only one button for the modal exists, which is `exit`
- when `exit` is clicked the shell shuts down
