### PR TITLE
Link to studio guide

### DIFF
--- a/templates/stylereference.html
+++ b/templates/stylereference.html
@@ -38,7 +38,7 @@ var sections = {
 %>
 
 <section class='small pad1x pad2y contain keyline-bottom'>
-  <a class='icon space-bottom1 book button col12 short' href='https://www.mapbox.com/mapbox-studio/' target='_blank'>Documentation</a>
+  <a class='icon space-bottom1 book button col12 short' href='https://www.mapbox.com/guides/getting-started-studio/' target='_blank'>Studio Guide</a>
   <a class='icon space-bottom2 star button col12 short js-demo' href='#demo'>Interface tour</a>
   <ul class='space-bottom1'>
     <li><kbd class='code prefixed'>s</kbd> Save.</li>


### PR DESCRIPTION
Per https://github.com/mapbox/mapbox-studio/issues/1354#event-306489956, now linking to [Getting started with Studio guide](https://www.mapbox.com/guides/getting-started-studio/). Also renamed since documentation this link is more specific.

![image](https://cloud.githubusercontent.com/assets/4587826/7692159/e4a72928-fd8e-11e4-8888-4c020bf478ce.png)

/cc @geografa @springmeyer 
