### PR TITLE
Update to mapbox-upload 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "mapbox-studio-default-source": "1.0.0",
     "cors": "~2.3.1",
     "request": "~2.48.0",
-    "mapbox-upload": "~3.0.0",
+    "mapbox-upload": "~3.2.0",
     "progress-stream": "0.5.0",
     "safer-stringify": "0.0.1",
     "gazetteer": "0.1.4",


### PR DESCRIPTION
Once mapbox-upload 3.2.0 is launched, this can be merged to make uploads from studio private.
