### PR TITLE
Directly access fields on datasource

### DIFF
--- a/lib/source.js
+++ b/lib/source.js
@@ -397,7 +397,7 @@ source.normalize = function(data) {
 
             if (opts.file && !tm.absolute(opts.file)) opts.base = tm.parse(data.id).dirname;
 
-            var fields = new mapnik.Datasource(opts).describe().fields;
+            var fields = new mapnik.Datasource(opts).fields();
             info.fields = _(fields).reduce(function(memo, type, field) {
                 memo[field] = l.fields[field] || type;
                 return memo;


### PR DESCRIPTION
This change takes advantage of mapnik/node-mapnik#450 and retrieves datasource fields directly, rather than calling `describe()`, which is potentially expensive.
