### PR TITLE
Bundle Windows C++ Runtime (vcredist)

### DIFF
--- a/scripts/build-atom.sh
+++ b/scripts/build-atom.sh
@@ -113,8 +113,19 @@ if [ $platform == "win32" ]; then
 
     rm $build_dir/mapbox-studio.exe.bak
 
-    echo "downloading c++ lib vcredist_$arch_common_name.exe"
-    curl -Lfo "$build_dir/resources/app/vendor/vcredist_$arch_common_name.exe" "https://mapbox.s3.amazonaws.com/windows-builds/visual-studio-runtimes/vcredist-VS2014-CTP4/vcredist_$arch_common_name.exe"
+    #bundle runtime DLLs directly into vendor and node-mapnik binding directory
+    vc_runtime_version="VS2014-CTP4"
+    vc_runtime_file="vcredist_${arch_common_name}-mini.7z"
+    vc_runtime_file_local="/tmp/vcredist_${arch_common_name}-mini.7z"
+    vc_runtime_url="https://mapbox.s3.amazonaws.com/windows-builds/visual-studio-runtimes/vcredist-${vc_runtime_version}/${vc_runtime_file}"
+
+    echo "downloading c++ lib ${vc_runtime_file}"
+    curl -Lfo $vc_runtime_file_local $vc_runtime_url
+    echo "extracting c++ lib to $build_dir"
+    7z -y e $vc_runtime_file -o"$build_dir/resources/app/vendor/"
+    echo "extracting c++ lib to node-mapnik binding dir"
+    #TODO determine node version automatically
+    7z -y e $vc_runtime_file -o"$build_dir/resources/app/node_modules/mapnik/lib/binding/node-v11-win32-${arch_common_name}/"
 
     if [[ $arch == "x64" ]]; then
         # alternative package for windows: no-installer / can be run from usb drive

--- a/scripts/build-atom.sh
+++ b/scripts/build-atom.sh
@@ -125,7 +125,7 @@ if [ $platform == "win32" ]; then
     7z -y e $vc_runtime_file -o"$build_dir/resources/app/vendor/"
     echo "extracting c++ lib to node-mapnik binding dir"
     #TODO determine node version automatically
-    7z -y e $vc_runtime_file -o"$build_dir/resources/app/node_modules/mapnik/lib/binding/node-v11-win32-${arch_common_name}/"
+    7z -y e $vc_runtime_file -o"$build_dir/resources/app/node_modules/mapnik/lib/binding/node-v11-win32-${arch}/"
 
     if [[ $arch == "x64" ]]; then
         # alternative package for windows: no-installer / can be run from usb drive

--- a/scripts/mapbox-studio.nsi
+++ b/scripts/mapbox-studio.nsi
@@ -141,7 +141,6 @@ Section "MainSection" SEC01
   SetOverwrite try
   SetOutPath "$INSTDIR"
   File /r ${SOURCE_ROOT}*.*
-  ExecWait "$INSTDIR\resources\app\vendor\vcredist_${TARGET_ARCH}.exe /q /norestart"
 SectionEnd
 
 ; Add firewall rule

--- a/scripts/mapbox-studio.nsi
+++ b/scripts/mapbox-studio.nsi
@@ -86,7 +86,7 @@ App_Running_Check:
   ${EndIf}
 
   StrCpy $INSTDIR "$programfiles32\${PRODUCT_DIR}"
-  ${If} ${RunningX64}
+  ${If} ${RunningX64} ${AndIf} ${TARGET_ARCH} == "x64"
     StrCpy $INSTDIR "$programfiles64\${PRODUCT_DIR}"
   ${EndIf}
 

--- a/scripts/mapbox-studio.nsi
+++ b/scripts/mapbox-studio.nsi
@@ -86,8 +86,10 @@ App_Running_Check:
   ${EndIf}
 
   StrCpy $INSTDIR "$programfiles32\${PRODUCT_DIR}"
-  ${If} ${RunningX64} ${AndIf} ${TARGET_ARCH} == "x64"
-    StrCpy $INSTDIR "$programfiles64\${PRODUCT_DIR}"
+  ${If} ${RunningX64}
+    ${If} ${TARGET_ARCH} == "x64"
+      StrCpy $INSTDIR "$programfiles64\${PRODUCT_DIR}"
+    ${EndIf}
   ${EndIf}
 
   StrCpy $PREV_VER_DIR ""


### PR DESCRIPTION
- downloads vcredist DLLs and bundles them into the installer
- execution of `vcredist.exe` during install is not necessary anymore

Refs #1404
