### PR TITLE
increase max size for bodyParser.json

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -24,7 +24,7 @@ var logger = require('fastlog')('', 'debug', '<${timestamp}> ${level}');
 var mapnik = require('mapnik');
 carto.tree.Reference.setVersion(mapnik.versions.mapnik);
 
-app.use(bodyParser.json());
+app.use(bodyParser.json( { limit: "512kb" } ));
 app.use(middleware.normalizePaths);
 app.use(require('./oauth'));
 app.use(app.router);


### PR DESCRIPTION
This is needed to support sources with large number of layers and long descriptions. I have tested this with a source with 136 layers, it was previously not possible to edit this source with the source editor, but viewing it and generating tiles works correctly, after this patch it works correctly.
