### PR TITLE
refs #878, conflict between tab shortcuts and special characters on …

### DIFF
--- a/app/style.js
+++ b/app/style.js
@@ -342,7 +342,7 @@ Editor.prototype.keys = function(ev) {
     ev.preventDefault();
     window.editor.addBookmark(ev);
     break;
-  case ((which > 48 && which < 58) && ev.altKey): // 1-9
+  case ((which > 48 && which < 55) && ev.altKey): // 1-6
     var tab = $('#tabs a.tab')[(which-48)-1];
     if (tab) $(tab).click();
     break;


### PR DESCRIPTION
…keyboard layouts other than US.

e.g. on German keyboard you need to press AltGr+7 to get "{".
Didn't find a way to detect keyboard layout via Javascript, so, this reduces the tab short cuts to 1-6.
Might need to be revisited for other keyboard layouts.
