### PR TITLE
Add srid to postgis template. Refs #1217

### DIFF
--- a/templates/layerpostgis.html
+++ b/templates/layerpostgis.html
@@ -54,6 +54,7 @@
         </div>
         <input type='hidden' name='Datasource-type' value='postgis' />
         <input type='hidden' name='Datasource-max_size' value='512' />
+        <input type='hidden' name='Datasource-srid' value='<%= obj.Datasource.srid %>' />
       </section>
       <section class='clearfix pad2x pad1y keyline-bottom'>
         <label class='pad0y col3 inline'>Extent </label>


### PR DESCRIPTION
This is a good change overall, and required for keeping studio working with upcoming node-mapnik releases which use a Mapnik version that no longer silently fails when the projection cannot be determined.
