### PR TITLE
Add license information

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,6 @@
     "pretest": "npm ls --depth=Infinity && tape ./test/duplicate_module.pretest.js",
     "test": "tape test/*.test.js",
     "posttest": "node test/cleanup.js"
-  }
+  },
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
This change gets rid of the `npm WARN package.json mapbox-studio@0.3.2 No license field.` warning.

<img width="578" alt="screen shot 2015-10-30 at 7 45 17 pm" src="https://cloud.githubusercontent.com/assets/432489/10860930/ed63b342-7f3e-11e5-83e3-d1b3aff89172.png">

SPDX link for the license: http://spdx.org/licenses/BSD-3-Clause.html
