### PR TITLE
fix clamp function: always returned WebMerc max bbox before

### DIFF
--- a/app/source.js
+++ b/app/source.js
@@ -507,14 +507,14 @@ window.Source = function(templates, cwd, tm, source, revlayers, examples, isMapb
 
     Editor.prototype.fitBounds = function(map,extent) {
         // https://github.com/mapbox/mapbox-studio/issues/1388
-        function clamp(value,expected) {
-            if (value > expected || value < expected) return expected;
-            return value;
+        function clamp(value, min, max, defaultvalue) {
+            return ((value < min) || (value > max)) ? defaultvalue : value;
         }
-        map.fitBounds([
-            [clamp(extent[1],-180),clamp(extent[0],-85.0511)],
-            [clamp(extent[3],180),clamp(extent[2],85.0511)]
-        ],{'animate': false});
+        var bounds = [
+            [clamp(extent[1], -85.0511, 85.0511, -85.0511), clamp(extent[0], -180, 180, -180)],
+            [clamp(extent[3], -85.0511, 85.0511, 85.0511), clamp(extent[2], -180, 180, 180)]
+        ];
+        map.fitBounds(bounds,{'animate': false});
     };
 
     Editor.prototype.update = function(ev) {


### PR DESCRIPTION
@springmeyer 
breakdown of the problem:
https://github.com/mapbox/mapbox-studio-classic/issues/1487#issuecomment-150641011
