### PR TITLE
Fix query assumptions with mapnik 3.4.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 Changelog
 =========
 
+### 0.4.0
+
+- Update tilelive-bridge to validate mapnik XML at source creation
+- `.index` files for shapefiles [are no longer backwards compatible](https://github.com/mapbox/mapbox-studio-classic/issues/1523) and must be regenerated. New index files can be regenerated locally on OS X:
+```
+cd ~/Downloads/mapbox-studio-darwin-x64-v0.3.3
+"Mapbox Studio.app/Contents/Resources/app/vendor/node" "Mapbox Studio.app/Contents/Resources/app/node_modules/mapnik/bin/mapnik-shapeindex.js" <path/to/shapefile.shp>
+```
+- Update node-mapnik (v3.4.18) to support backwards compatible vector tiles (v1/v2)
+- Update node-gdal ([v0.8.0](https://github.com/naturalatlas/node-gdal/releases))
+- Update tilelive-vector to include tm2z bug fixes, `transparent` background support for xray tiles, [etc](https://github.com/mapbox/tilelive-vector/blob/master/CHANGELOG.md)
+- Update mapnik-omnivore with maxzoom adjustments for rasters, shapefile projection bug fix, and dep updates
+- Update minor dependencies
+
 ### 0.3.2
 
 - Updated to use node-mapnik 3.4.9

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "js-yaml": "https://github.com/mapbox/js-yaml/tarball/scalar-styles",
     "fstream": "1.0.x",
     "tar": "2.2.x",
-    "mapnik": "3.4.16",
+    "mapnik": "git://github.com/mapnik/node-mapnik.git#3.4.x",
     "mapnik-reference": "~8.5.1",
     "carto": "0.15.3",
     "tilelive": "~5.11.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "minimist": "1.2.x",
     "underscore": "1.6.x",
     "tilejson": "git://github.com/mapbox/node-tilejson.git#request-mbs2",
-    "mbtiles": "0.8.0",
+    "mbtiles": "~0.8.2",
     "mkdirp": "0.5.x",
     "dirty": "1.0.0",
     "sphericalmercator": "1.0.x",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "js-yaml": "https://github.com/mapbox/js-yaml/tarball/scalar-styles",
     "fstream": "1.0.x",
     "tar": "2.2.x",
-    "mapnik": "git://github.com/mapnik/node-mapnik.git#3.4.x",
+    "mapnik": "3.4.18",
     "mapnik-reference": "~8.5.1",
     "carto": "0.15.3",
     "tilelive": "~5.11.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "js-yaml": "https://github.com/mapbox/js-yaml/tarball/scalar-styles",
     "fstream": "1.0.x",
     "tar": "2.2.x",
-    "mapnik": "3.4.18",
+    "mapnik": "3.4.19",
     "mapnik-reference": "~8.5.1",
     "carto": "0.15.3",
     "tilelive": "~5.11.0",

--- a/scripts/build-appveyor.bat
+++ b/scripts/build-appveyor.bat
@@ -31,16 +31,17 @@ ECHO fetching %NODE_URL%
 powershell Invoke-WebRequest $env:NODE_URL -OutFile $env:HOME\node.exe
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
-IF EXIST "%ProgramFiles(x86)%\nodejs\node.exe" DEL /Q "%ProgramFiles(x86)%\nodejs\node.exe"
+IF EXIST "%ProgramFiles(x86)%\nodejs\node.exe" ECHO found "%ProgramFiles(x86)%\nodejs\node.exe" && DEL /Q "%ProgramFiles(x86)%\nodejs\node.exe"
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-IF EXIST "%ProgramFiles%\nodejs\node.exe" DEL /Q "%ProgramFiles%\nodejs\node.exe"
-IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-
-IF EXIST "%ProgramFiles(x86)%\nodejs" COPY node.exe "%ProgramFiles(x86)%\nodejs\"
-IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-IF EXIST "%ProgramFiles%\nodejs" COPY node.exe "%ProgramFiles%\nodejs\"
+IF EXIST "%ProgramFiles%\nodejs\node.exe" ECHO found "%ProgramFiles%\nodejs\node.exe" && DEL /Q "%ProgramFiles%\nodejs\node.exe"
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
+IF EXIST "%ProgramFiles(x86)%\nodejs" ECHO copying node.exe to "%ProgramFiles(x86)%\nodejs" && COPY node.exe "%ProgramFiles(x86)%\nodejs\"
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+IF EXIST "%ProgramFiles%\nodejs" ECHO copying node.exe to "%ProgramFiles%\nodejs" && COPY node.exe "%ProgramFiles%\nodejs\"
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+WHERE node
 
 :RUN_INSTALL
 

--- a/scripts/build-appveyor.bat
+++ b/scripts/build-appveyor.bat
@@ -31,6 +31,16 @@ ECHO fetching %NODE_URL%
 powershell Invoke-WebRequest $env:NODE_URL -OutFile $env:HOME\node.exe
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
+IF EXIST "%ProgramFiles(x86)%\nodejs\node.exe" DEL /Q "%ProgramFiles(x86)%\nodejs\node.exe"
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+IF EXIST "%ProgramFiles%\nodejs\node.exe" DEL /Q "%ProgramFiles%\nodejs\node.exe"
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+IF EXIST "%ProgramFiles(x86)%\nodejs" COPY node.exe "%ProgramFiles(x86)%\nodejs\"
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+IF EXIST "%ProgramFiles%\nodejs" COPY node.exe "%ProgramFiles%\nodejs\"
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
 
 :RUN_INSTALL
 


### PR DESCRIPTION
Fixes an issue in the node-mapnik 3.4 series where the vector-tile decoder was assuming the layer tags came before geometries, which was breaking when reading version 2 tiles where that assumption is not guaranteed.

This should be released as soon as possible, since it's blocking the launch of V2 tiles.

cc/ @springmeyer @rclark @yhahn @flippmoke @GretaCB 
