### PR TITLE
update mapbox-upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "mapbox-studio-default-source": "1.0.0",
     "cors": "~2.7.1",
     "request": "~2.60.0",
-    "mapbox-upload": "~4.1.0",
+    "mapbox-upload": "4.2.x",
     "progress-stream": "1.1.1",
     "safer-stringify": "0.0.1",
     "gazetteer": "0.1.4",


### PR DESCRIPTION
tests with `4.2.1` work great - this should fix #1525 and get us close to the `v0.3.4` milestone!

Do we want to semver to `4.2.x` (current status) or go with `4.x.x` suggested in #1525? 

cc/ @springmeyer @willwhite 
