### PR TITLE
Carto rollback

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "tar": "2.2.x",
     "mapnik": "3.5.13",
     "mapnik-reference": "~8.5.5",
-    "carto": "0.16.2",
+    "carto": "0.15.3",
     "tilelive": "~5.12.0",
     "tilelive-bridge": "~2.3.0",
     "tilelive-vector": "~3.9.1",


### PR DESCRIPTION
Rolls back to carto v0.15.x until regressions in color parsing are fully understood/resolved in the v0.16.x series. #1558
