### PR TITLE
Publishing fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,50 @@
+version: 2
+
+step-library:
+  - &install-node
+      run:
+        name: Install node
+        command: |
+          set +e
+          curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
+          [ -s "${NVM_DIR}/nvm.sh" ] && \. "${NVM_DIR}/nvm.sh"
+          nvm install ${$NODE_VERSION}
+          nvm alias default ${$NODE_VERSION}
+          echo "[ -s \"${NVM_DIR}/nvm.sh\" ] && . \"${NVM_DIR}/nvm.sh\"" >> $BASH_ENV
+
+  - &build-and-test
+      run:
+        name: Build and test
+        command: |
+          node -v
+          npm -v
+          ./scripts/build-travis.sh $TRAVIS_COMMIT
+          npm install --fallback-to-build=false
+          python test/check_shared_libs.py node_modules/
+          npm ls
+          npm test
+
+jobs:
+  build-osx:
+    macos:
+      xcode: "9.0"
+    environment:
+      - FOO: "bar"
+      - NODE_VERSION: "0.10.40"
+      - ATOM_VERSION: "0.21.1"
+      - PACKAGABLE: true
+      - TRAVIS_COMMIT: $(echo $CIRCLE_SHA1 | cut -c -7)
+      - WINCERT_PASSWORD: "not-actually-password" # to prevent Unbound var error in script (not used on OS X)
+
+    steps:
+      - checkout
+      - run: echo 'export NVM_DIR=${HOME}/.nvm' >> $BASH_ENV
+      - *install-node
+      - *build-and-test
+
+
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      - build-osx

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ step-library:
           set +e
           curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
           [ -s "${NVM_DIR}/nvm.sh" ] && \. "${NVM_DIR}/nvm.sh"
-          nvm install ${$NODE_VERSION}
-          nvm alias default ${$NODE_VERSION}
+          nvm install ${NODE_VERSION}
+          nvm alias default ${NODE_VERSION}
           echo "[ -s \"${NVM_DIR}/nvm.sh\" ] && . \"${NVM_DIR}/nvm.sh\"" >> $BASH_ENV
 
   - &build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ step-library:
 jobs:
   build-osx:
     macos:
-      xcode: "8.3"
+      xcode: "9.2.0"
     environment:
       - FOO: "bar"
       - NODE_VERSION: "0.10.40"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ step-library:
 jobs:
   build-osx:
     macos:
-      xcode: "9.0"
+      xcode: "8.2"
     environment:
       - FOO: "bar"
       - NODE_VERSION: "0.10.40"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ step-library:
         command: |
           node -v
           npm -v
-          ./scripts/build-travis.sh $TRAVIS_COMMIT
+          ./scripts/build-travis.sh $(echo $CIRCLE_SHA1 | cut -c -7)
           npm install --fallback-to-build=false
           python test/check_shared_libs.py node_modules/
           npm ls
@@ -33,7 +33,6 @@ jobs:
       - NODE_VERSION: "0.10.40"
       - ATOM_VERSION: "0.21.1"
       - PACKAGABLE: true
-      - TRAVIS_COMMIT: $(echo $CIRCLE_SHA1 | cut -c -7)
       - WINCERT_PASSWORD: "not-actually-password" # to prevent Unbound var error in script (not used on OS X)
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ step-library:
 jobs:
   build-osx:
     macos:
-      xcode: "8.2"
+      xcode: "8.3"
     environment:
       - FOO: "bar"
       - NODE_VERSION: "0.10.40"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ compiler:
 
 os:
   - linux
-  - osx
 
 dist: trusty
 

--- a/scripts/build-atom.sh
+++ b/scripts/build-atom.sh
@@ -175,16 +175,17 @@ elif [ $platform == "darwin" ]; then
     aws s3 cp "s3://mapbox/mapbox-studio/keys2/Developer ID Application- Mapbox, Inc. (GJZR2MEM28).cer" signing-key.cer
     aws s3 cp "s3://mapbox/mapbox-studio/keys2/Mac Developer ID Application- Mapbox, Inc..p12" signing-key.p12
     KEYCHAIN_NAME="signing.keychain"
-    security create-keychain -p travis ${KEYCHAIN_NAME} \
+    KEYCHAIN_PASSWORD="travis"
+    security create-keychain -p ${KEYCHAIN_PASSWORD} ${KEYCHAIN_NAME} \
         && echo "+ signing keychain created"
     security list-keychains -s ${KEYCHAIN_NAME}
     security list-keychains
     security show-keychain-info ${KEYCHAIN_NAME}
-    security import authority.cer -k ~/Library/Keychains/${KEYCHAIN_NAME} -T /usr/bin/codesign \
+    security import authority.cer -k ~/Library/Keychains/${KEYCHAIN_NAME} -T /usr/bin/codesign -A \
         && echo "+ authority cer added to keychain"
-    security import signing-key.cer -k ~/Library/Keychains/${KEYCHAIN_NAME} -T /usr/bin/codesign \
+    security import signing-key.cer -k ~/Library/Keychains/${KEYCHAIN_NAME} -T /usr/bin/codesign -A \
         && echo "+ signing cer added to keychain"
-    security import signing-key.p12 -k ~/Library/Keychains/${KEYCHAIN_NAME} -P "" -T /usr/bin/codesign \
+    security import signing-key.p12 -k ~/Library/Keychains/${KEYCHAIN_NAME} -P "" -T /usr/bin/codesign -A \
         && echo "+ signing key added to keychain"
     rm authority.cer
     rm signing-key.cer
@@ -194,6 +195,8 @@ elif [ $platform == "darwin" ]; then
     sudo ntpdate -u time.apple.com
 
     # Sign .app file.
+    which codesign
+    security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/${KEYCHAIN_NAME}
     codesign --keychain ~/Library/Keychains/${KEYCHAIN_NAME} --sign "Developer ID Application: Mapbox, Inc." --deep --verbose --force "$build_dir/Mapbox Studio.app"
 
     # Nuke signin keychain.

--- a/scripts/build-atom.sh
+++ b/scripts/build-atom.sh
@@ -176,8 +176,8 @@ elif [ $platform == "darwin" ]; then
     aws s3 cp "s3://mapbox/mapbox-studio/keys2/Mac Developer ID Application- Mapbox, Inc..p12" signing-key.p12
     KEYCHAIN_NAME="circle.keychain"
     KEYCHAIN_PASSWORD="circle"
-    #security create-keychain -p ${KEYCHAIN_PASSWORD} ${KEYCHAIN_NAME} \
-    #    && echo "+ signing keychain created"
+    security create-keychain -p ${KEYCHAIN_PASSWORD} ${KEYCHAIN_NAME} \
+        && echo "+ signing keychain created"
     security list-keychains -s ${KEYCHAIN_NAME}
     security list-keychains -d user -s login.keychain
     security list-keychains

--- a/scripts/build-atom.sh
+++ b/scripts/build-atom.sh
@@ -189,6 +189,9 @@ elif [ $platform == "darwin" ]; then
         && echo "+ signing cer added to keychain"
     security import signing-key.p12 -k ~/Library/Keychains/${KEYCHAIN_NAME} -P "" -T /usr/bin/codesign -A \
         && echo "+ signing key added to keychain"
+
+    security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k ${KEYCHAIN_PASSWORD} ${KEYCHAIN_NAME}
+
     rm authority.cer
     rm signing-key.cer
     rm signing-key.p12

--- a/scripts/build-atom.sh
+++ b/scripts/build-atom.sh
@@ -190,7 +190,7 @@ elif [ $platform == "darwin" ]; then
     sudo ntpdate -u time.apple.com
 
     # Sign .app file.
-    codesign --keychain ~/Library/Keychains/signing.keychain --sign "Developer ID Application: Mapbox, Inc." --deep --verbose --force "$build_dir/Mapbox Studio.app"
+    codesign --keychain ~/Library/Keychains/signing.keychain --sign "Developer ID Application: Mapbox, Inc." --deep --verbose --force "$build_dir/Mapbox Studio.app" || true
 
     # Nuke signin keychain.
     security delete-keychain signing.keychain

--- a/scripts/build-atom.sh
+++ b/scripts/build-atom.sh
@@ -179,7 +179,6 @@ elif [ $platform == "darwin" ]; then
     security create-keychain -p ${KEYCHAIN_PASSWORD} ${KEYCHAIN_NAME} \
         && echo "+ signing keychain created"
     security list-keychains -s ${KEYCHAIN_NAME}
-    security list-keychains -d user -s login.keychain
     security list-keychains
     security show-keychain-info ${KEYCHAIN_NAME}
     security unlock-keychain -p ${KEYCHAIN_PASSWORD} ${KEYCHAIN_NAME}

--- a/scripts/build-atom.sh
+++ b/scripts/build-atom.sh
@@ -171,9 +171,9 @@ elif [ $platform == "darwin" ]; then
     mv $build_dir/Atom.app "$build_dir/Mapbox Studio.app"
 
     # Test getting signing key.
-    aws s3 cp "s3://mapbox/mapbox-studio/keys/Developer ID Certification Authority.cer" authority.cer
-    aws s3 cp "s3://mapbox/mapbox-studio/keys/Developer ID Application: Mapbox, Inc. (GJZR2MEM28).cer" signing-key.cer
-    aws s3 cp "s3://mapbox/mapbox-studio/keys/Mac Developer ID Application: Mapbox, Inc..p12" signing-key.p12
+    aws s3 cp "s3://mapbox/mapbox-studio/keys2/Developer ID Certification Authority.cer" authority.cer
+    aws s3 cp "s3://mapbox/mapbox-studio/keys2/Developer ID Application- Mapbox, Inc. (GJZR2MEM28).cer" signing-key.cer
+    aws s3 cp "s3://mapbox/mapbox-studio/keys2/Mac Developer ID Application- Mapbox, Inc..p12" signing-key.p12
     security create-keychain -p travis signing.keychain \
         && echo "+ signing keychain created"
     security import authority.cer -k ~/Library/Keychains/signing.keychain -T /usr/bin/codesign \
@@ -186,11 +186,11 @@ elif [ $platform == "darwin" ]; then
     rm signing-key.cer
     rm signing-key.p12
 
-    # update time to try to avoid occaisonal codesign error of "timestamps differ by N seconds - check your system clock"
+    # update time to try to avoid occasional codesign error of "timestamps differ by N seconds - check your system clock"
     sudo ntpdate -u time.apple.com
 
     # Sign .app file.
-    codesign --keychain ~/Library/Keychains/signing.keychain --sign "Developer ID Application: Mapbox, Inc." --deep --verbose --force "$build_dir/Mapbox Studio.app" || true
+    codesign --keychain ~/Library/Keychains/signing.keychain --sign "Developer ID Application: Mapbox, Inc." --deep --verbose --force "$build_dir/Mapbox Studio.app"
 
     # Nuke signin keychain.
     security delete-keychain signing.keychain

--- a/scripts/build-atom.sh
+++ b/scripts/build-atom.sh
@@ -174,13 +174,17 @@ elif [ $platform == "darwin" ]; then
     aws s3 cp "s3://mapbox/mapbox-studio/keys2/Developer ID Certification Authority.cer" authority.cer
     aws s3 cp "s3://mapbox/mapbox-studio/keys2/Developer ID Application- Mapbox, Inc. (GJZR2MEM28).cer" signing-key.cer
     aws s3 cp "s3://mapbox/mapbox-studio/keys2/Mac Developer ID Application- Mapbox, Inc..p12" signing-key.p12
-    security create-keychain -p travis signing.keychain \
+    KEYCHAIN_NAME="signing.keychain"
+    security create-keychain -p travis ${KEYCHAIN_NAME} \
         && echo "+ signing keychain created"
-    security import authority.cer -k ~/Library/Keychains/signing.keychain -T /usr/bin/codesign \
+    security list-keychains -s ${KEYCHAIN_NAME}
+    security list-keychains
+    security show-keychain-info ${KEYCHAIN_NAME}
+    security import authority.cer -k ~/Library/Keychains/${KEYCHAIN_NAME} -T /usr/bin/codesign \
         && echo "+ authority cer added to keychain"
-    security import signing-key.cer -k ~/Library/Keychains/signing.keychain -T /usr/bin/codesign \
+    security import signing-key.cer -k ~/Library/Keychains/${KEYCHAIN_NAME} -T /usr/bin/codesign \
         && echo "+ signing cer added to keychain"
-    security import signing-key.p12 -k ~/Library/Keychains/signing.keychain -P "" -T /usr/bin/codesign \
+    security import signing-key.p12 -k ~/Library/Keychains/${KEYCHAIN_NAME} -P "" -T /usr/bin/codesign \
         && echo "+ signing key added to keychain"
     rm authority.cer
     rm signing-key.cer
@@ -190,10 +194,10 @@ elif [ $platform == "darwin" ]; then
     sudo ntpdate -u time.apple.com
 
     # Sign .app file.
-    codesign --keychain ~/Library/Keychains/signing.keychain --sign "Developer ID Application: Mapbox, Inc." --deep --verbose --force "$build_dir/Mapbox Studio.app"
+    codesign --keychain ~/Library/Keychains/${KEYCHAIN_NAME} --sign "Developer ID Application: Mapbox, Inc." --deep --verbose --force "$build_dir/Mapbox Studio.app"
 
     # Nuke signin keychain.
-    security delete-keychain signing.keychain
+    security delete-keychain ${KEYCHAIN_NAME}
 
     # Use ditto rather than zip to preserve code signing.
     ditto -c -k --sequesterRsrc --keepParent --zlibCompressionLevel 9 $(basename $build_dir) $build_dir.zip

--- a/scripts/build-travis.sh
+++ b/scripts/build-travis.sh
@@ -29,7 +29,7 @@ if [[ ${PACKAGABLE:-false} == true ]]; then
 
         curl -O https://bootstrap.pypa.io/get-pip.py
         sudo python get-pip.py
-        sudo pip install -q awscli
+        pip install awscli --user
 
         ./scripts/build-atom.sh "$GITSHA" darwin
     else

--- a/scripts/build-travis.sh
+++ b/scripts/build-travis.sh
@@ -25,12 +25,12 @@ if [[ ${PACKAGABLE:-false} == true ]]; then
         aws s3 cp --acl=public-read index.html s3://mapbox/mapbox-studio/index.html
     elif [ $PLATFORM == "darwin" ] && [ -n "$GITSHA" ]; then
         echo "Publishing $GITSHA"
-        brew install python
-        brew link --overwrite python
-
         set -eu
 
-        pip install -q awscli
+        curl -O https://bootstrap.pypa.io/get-pip.py
+        sudo python get-pip.py
+        sudo pip install -q awscli
+
         ./scripts/build-atom.sh "$GITSHA" darwin
     else
         echo "Not publishing for $PLATFORM / $GITSHA / node $NODE_VERSION / atom $ATOM_VERSION"

--- a/scripts/build-travis.sh
+++ b/scripts/build-travis.sh
@@ -30,6 +30,7 @@ if [[ ${PACKAGABLE:-false} == true ]]; then
         curl -O https://bootstrap.pypa.io/get-pip.py
         sudo python get-pip.py
         pip install awscli --user
+        export PATH=$(python -m site --user-base)/bin:${PATH}
 
         ./scripts/build-atom.sh "$GITSHA" darwin
     else

--- a/scripts/generate-s3-listing.py
+++ b/scripts/generate-s3-listing.py
@@ -25,12 +25,12 @@ downloads = {}
 for line in fileinput.input():
     stripped = line.strip()
     if 'mapbox-studio-' in stripped:
-        parts = stripped.split(' ')
+        parts = [i for i in stripped.split(' ') if i != '']
         date = parts[0]
         time = parts[1]
-        size = '%s MB' % (int(parts[3])/1000000)
-        name = parts[4]
-        gitSHA = '-'.join(os.path.splitext(name)[0].split('-')[4:])
+        size = '%s MB' % (int(parts[2])/1000000)
+        name = parts[3]
+        gitSHA = '-'.join(os.path.splitext(name)[0].split('-')[3:])
         downloads[date+name] = line_template % (locals())
 
 sorted_by_date = sorted(downloads, key=lambda key: downloads[key], reverse=True)


### PR DESCRIPTION
This repairs the publishing scripts, fixing:

 - a bug in the `generate-s3-listing.py` script which surfaced due to different upload sizes
 - incorrect/broken install of python pip on OS X
 - codesigning on OS X, which needed:
   - new certs (others had expired)
   - the code signing commands to be adapted to changes in how xcode commands work in xcode 9 vs 8.2)

Along the way I moved from travis to circleci 2.0 for OS X support, since travis was too slow to practically debug the codesigning issue (which took quite a bit of tries to get working).

Thanks @boundsj for the help getting new certs going.